### PR TITLE
Memory leak fixed. DocPane was holding reference to the last document. 

### DIFF
--- a/WinFormsUI/Docking/DockContentHandler.cs
+++ b/WinFormsUI/Docking/DockContentHandler.cs
@@ -874,13 +874,12 @@ namespace WeifenLuo.WinFormsUI.Docking
 
 		public void Close()
 		{
-			DockPanel dockPanel = DockPanel;
+            DockPanel dockPanel = DockPanel;
             if (dockPanel != null)
                 dockPanel.SuspendLayout(true);
-			Form.Close();
+            Form.Close();
 			if (dockPanel != null)
 				dockPanel.ResumeLayout(true, true);
-
 		}
 
 		private DockPaneStripBase.Tab m_tab = null;

--- a/WinFormsUI/Docking/DockPane.cs
+++ b/WinFormsUI/Docking/DockPane.cs
@@ -214,6 +214,10 @@ namespace WeifenLuo.WinFormsUI.Docking
                     TabStripControl.EnsureTabVisible(m_activeContent);
             }
         }
+        public void ClearLastActiveContent()
+        {
+            m_activeContent = null;
+        }
 
         private bool m_allowDockDragAndDrop = true;
         public virtual bool AllowDockDragAndDrop

--- a/WinFormsUI/Docking/DockPaneStripBase.cs
+++ b/WinFormsUI/Docking/DockPaneStripBase.cs
@@ -258,5 +258,11 @@ namespace WeifenLuo.WinFormsUI.Docking
                     DockPane.ActiveContent = content;
             }
         }
+
+	    protected void ContentClosed()
+	    {
+            if (m_tabs.Count == 0)
+                DockPane.ClearLastActiveContent();
+	    }
 	}
 }

--- a/WinFormsUI/Docking/VS2005DockPaneStrip.cs
+++ b/WinFormsUI/Docking/VS2005DockPaneStrip.cs
@@ -1440,6 +1440,7 @@ namespace WeifenLuo.WinFormsUI.Docking
         private void Close_Click(object sender, EventArgs e)
         {
             DockPane.CloseActiveContent();
+            base.ContentClosed();
         }
 
         protected internal override int HitTest(Point ptMouse)


### PR DESCRIPTION
Memory leak fixed. DocPane was holding reference to the last document. This is normally not a problem, however when the document is large, and will not be reused - meaning there will be no another ActiveContent on the particular pane, the memory will never be collected.
