### PR TITLE
Float Window Behavior when Double Clicked or Maximized

### DIFF
--- a/WinFormsUI/Docking/DockPanel.cs
+++ b/WinFormsUI/Docking/DockPanel.cs
@@ -46,6 +46,9 @@ namespace WeifenLuo.WinFormsUI.Docking
 			m_panes = new DockPaneCollection();
 			m_floatWindows = new FloatWindowCollection();
 
+			DefaultFloatWindowStyle = FormBorderStyle.FixedToolWindow;
+			DoubleClickReturnsFloatWindow = true;
+
             SuspendLayout();
 
 			m_autoHideWindow = new AutoHideWindowControl(this);
@@ -574,6 +577,27 @@ namespace WeifenLuo.WinFormsUI.Docking
         {
             DefaultFloatWindowSize = new Size(300, 300);
         }
+
+		/// <summary>
+		/// Gets or sets the default form border style for float windows.
+		/// </summary>
+		[Category("Layout")]
+		public FormBorderStyle DefaultFloatWindowStyle
+		{
+			get;
+			set;
+		}
+
+		/// <summary>
+		/// Gets or sets whether double clicking on a float window title bar 
+		/// returns it to it's owner dock panel. If false, double clicking maximizes the float 
+		/// window. True by default.
+		/// </summary>
+		public bool DoubleClickReturnsFloatWindow
+		{
+			get;
+			set;
+		}
 
 		private DocumentStyle m_documentStyle = DocumentStyle.DockingMdi;
 		[LocalizedCategory("Category_Docking")]

--- a/WinFormsUI/Docking/FloatWindow.cs
+++ b/WinFormsUI/Docking/FloatWindow.cs
@@ -30,7 +30,8 @@ namespace WeifenLuo.WinFormsUI.Docking
 
 			m_nestedPanes = new NestedPaneCollection(this);
 
-			FormBorderStyle = FormBorderStyle.SizableToolWindow;
+			FormBorderStyle = dockPanel.DefaultFloatWindowStyle;
+			MinimizeBox = false;
 			ShowInTaskbar = false;
             if (dockPanel.RightToLeft != RightToLeft)
                 RightToLeft = dockPanel.RightToLeft;
@@ -181,7 +182,7 @@ namespace WeifenLuo.WinFormsUI.Docking
 					return;
 
 				uint result = Win32Helper.IsRunningOnMono ? 0 : NativeMethods.SendMessage(this.Handle, (int)Win32.Msgs.WM_NCHITTEST, 0, (uint)m.LParam);
-				if (result == 2 && DockPanel.AllowEndUserDocking && this.AllowEndUserDocking)	// HITTEST_CAPTION
+				if (this.WindowState != FormWindowState.Maximized && result == 2 && DockPanel.AllowEndUserDocking && this.AllowEndUserDocking)	// HITTEST_CAPTION
 				{
 					Activate();
 					m_dockPanel.BeginDrag(this);
@@ -236,7 +237,7 @@ namespace WeifenLuo.WinFormsUI.Docking
 
                 return;
             }
-            else if (m.Msg == (int)Win32.Msgs.WM_NCLBUTTONDBLCLK)
+			else if (m_dockPanel != null && m_dockPanel.DoubleClickReturnsFloatWindow && m.Msg == (int)Win32.Msgs.WM_NCLBUTTONDBLCLK)
             {
                 uint result = Win32Helper.IsRunningOnMono ? 0: NativeMethods.SendMessage(this.Handle, (int)Win32.Msgs.WM_NCHITTEST, 0, (uint)m.LParam);
                 if (result != 2)	// HITTEST_CAPTION


### PR DESCRIPTION
Added properties to Dockpanel to specify how FloatWindows look (border style) and what they do when their title bar is double clicked (currently, they always return to their dockpanel). FloatWindow allows users to peel windows out of maximized state. They can then drag the window into a dock panel position.
