### PR TITLE
Memory leak fixed. FocusManagerImpl subscribes to event after Dispose

### DIFF
--- a/WinFormsUI/Docking/DockPanel.FocusManager.cs
+++ b/WinFormsUI/Docking/DockPanel.FocusManager.cs
@@ -296,7 +296,7 @@ namespace WeifenLuo.WinFormsUI.Docking
             public void SuspendFocusTracking()
             {
                 m_countSuspendFocusTracking++;
-                if (!Win32Helper.IsRunningOnMono)
+                if (!Win32Helper.IsRunningOnMono && !m_disposed)
                     sm_localWindowsHook.HookInvoked -= m_hookEventHandler;
             }
 
@@ -312,7 +312,7 @@ namespace WeifenLuo.WinFormsUI.Docking
                         Activate(ContentActivating);
                         ContentActivating = null;
                     }
-                    if (!Win32Helper.IsRunningOnMono)
+                    if (!Win32Helper.IsRunningOnMono && !m_disposed)
                         sm_localWindowsHook.HookInvoked += m_hookEventHandler;
                     if (!InRefreshActiveWindow)
                         RefreshActiveWindow();


### PR DESCRIPTION
When the document is closed will invoked a Dispose. After, a few times will invoked SuspendFocusTracking and ResumeFocusTracking. At the end of the ResumeFocusTracking subscribes to an event sm_localWindowsHook.HookInvoked.
