### PR TITLE
Added new property "WindowListButtonVisible"

### DIFF
--- a/DockSample/DummyDoc.Designer.cs
+++ b/DockSample/DummyDoc.Designer.cs
@@ -119,6 +119,7 @@ namespace DockSample
             this.ClientSize = new System.Drawing.Size(448, 393);
             this.Controls.Add(this.richTextBox1);
             this.Controls.Add(this.mainMenu);
+            this.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.mainMenu;
             this.Name = "DummyDoc";

--- a/DockSample/DummyDoc.resx
+++ b/DockSample/DummyDoc.resx
@@ -112,21 +112,21 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="mainMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="mainMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>261, 17</value>
   </metadata>
-  <metadata name="contextMenuTabPage.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="contextMenuTabPage.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>102, 17</value>
   </metadata>
-  <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAEAEBAQAAAAAAAoAQAAFgAAACgAAAAQAAAAIAAAAAEABAAAAAAAgAAAAAAAAAAAAAAAEAAAABAA

--- a/WinFormsUI/Docking/DockContent.cs
+++ b/WinFormsUI/Docking/DockContent.cs
@@ -92,6 +92,15 @@ namespace WeifenLuo.WinFormsUI.Docking
             set { DockHandler.CloseButtonVisible = value; }
         }
         
+        [LocalizedCategory("Category_Docking")]
+        [LocalizedDescription("DockContent_WindowListButtonVisible_Description")]
+        [DefaultValue(true)]
+        public bool WindowListButtonVisible
+        {
+            get { return DockHandler.WindowListButtonVisible; }
+            set { DockHandler.WindowListButtonVisible = value; }
+        }
+		
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public DockPanel DockPanel

--- a/WinFormsUI/Docking/DockContentHandler.cs
+++ b/WinFormsUI/Docking/DockContentHandler.cs
@@ -142,6 +142,15 @@ namespace WeifenLuo.WinFormsUI.Docking
             }
         }
 
+        private static bool m_windowListButtonVisible = true;
+
+        public bool WindowListButtonVisible
+        {
+            get { return m_windowListButtonVisible; }
+
+            set { m_windowListButtonVisible = value; }
+        }
+
         private bool IsActiveContentHandler
         {
             get { return Pane != null && Pane.ActiveContent != null && Pane.ActiveContent.DockHandler == this; }

--- a/WinFormsUI/Docking/VS2005DockPaneCaption.cs
+++ b/WinFormsUI/Docking/VS2005DockPaneCaption.cs
@@ -52,12 +52,12 @@ namespace WeifenLuo.WinFormsUI.Docking
         }
 
         #region consts
-        private const int _TextGapTop = 2;
-        private const int _TextGapBottom = 0;
+        private const int _TextGapTop = 1;
+        private const int _TextGapBottom = 1;
         private const int _TextGapLeft = 3;
         private const int _TextGapRight = 3;
-        private const int _ButtonGapTop = 2;
-        private const int _ButtonGapBottom = 1;
+        private const int _ButtonGapTop = 1;
+        private const int _ButtonGapBottom = 2;
         private const int _ButtonGapBetween = 1;
         private const int _ButtonGapLeft = 1;
         private const int _ButtonGapRight = 2;

--- a/WinFormsUI/Docking/VS2005DockPaneStrip.cs
+++ b/WinFormsUI/Docking/VS2005DockPaneStrip.cs
@@ -136,7 +136,7 @@ namespace WeifenLuo.WinFormsUI.Docking
         private static string m_toolTipSelect;
         private static string m_toolTipClose;
         private bool m_closeButtonVisible = false;
-
+        private bool m_windowListButtonVisible = false;
         #endregion
 
         #region Properties
@@ -1302,6 +1302,8 @@ namespace WeifenLuo.WinFormsUI.Docking
                 rect.Y + rect.Height - 1 - DocumentIconGapBottom - DocumentIconHeight,
                 DocumentIconWidth, DocumentIconHeight);
             Rectangle rectText = rectIcon;
+            rectText.Height += 3;
+
             if (DockPane.DockPanel.ShowDocumentIcon)
             {
                 rectText.X += rectIcon.Width + DocumentIconGapRight;
@@ -1393,6 +1395,12 @@ namespace WeifenLuo.WinFormsUI.Docking
                 m_closeButtonVisible = DockPane.ActiveContent == null ? true : DockPane.ActiveContent.DockHandler.CloseButtonVisible;
                 ButtonClose.Visible = m_closeButtonVisible;
                 ButtonClose.RefreshChanges();
+
+                m_windowListButtonVisible = DockPane.ActiveContent == null
+                                                ? true
+                                                : DockPane.ActiveContent.DockHandler.WindowListButtonVisible;
+                ButtonWindowList.Visible = m_windowListButtonVisible;
+
                 ButtonWindowList.RefreshChanges();
             }
         }


### PR DESCRIPTION
The "WindowsListButtonVisible" property allows hiding the window list
(down arrow) on document windows, which works like the
CloseButtonVisible property. This feature only works with VS2005 and
VS2012 themes since the VS2003 theme uses left/right arrows instead. The
VS2012 theme is not in this branch, so the appropriate branch will be
updated so VS2012 theme contains the logic to hide the window list arrow
button. Also, fixed the placement of the text and icons on tool windows
to be perfectly centered.
