### PR TITLE
Added "WindowListButtonVisible" property

### DIFF
--- a/DockSample/DummyDoc.Designer.cs
+++ b/DockSample/DummyDoc.Designer.cs
@@ -119,11 +119,13 @@ namespace DockSample
             this.ClientSize = new System.Drawing.Size(448, 393);
             this.Controls.Add(this.richTextBox1);
             this.Controls.Add(this.mainMenu);
+            this.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.mainMenu;
             this.Name = "DummyDoc";
             this.Padding = new System.Windows.Forms.Padding(0, 4, 0, 0);
             this.TabPageContextMenuStrip = this.contextMenuTabPage;
+            this.WindowListButtonVisible = false;
             this.mainMenu.ResumeLayout(false);
             this.mainMenu.PerformLayout();
             this.contextMenuTabPage.ResumeLayout(false);

--- a/WinFormsUI/Docking/DockContent.cs
+++ b/WinFormsUI/Docking/DockContent.cs
@@ -92,6 +92,15 @@ namespace WeifenLuo.WinFormsUI.Docking
             set { DockHandler.CloseButtonVisible = value; }
         }
         
+        [LocalizedCategory("Category_Docking")]
+        [LocalizedDescription("DockContent_WindowListButtonVisible_Description")]
+        [DefaultValue(true)]
+        public bool WindowListButtonVisible
+        {
+            get { return DockHandler.WindowListButtonVisible; }
+            set { DockHandler.WindowListButtonVisible = value; }
+        }
+		
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public DockPanel DockPanel

--- a/WinFormsUI/Docking/DockContentHandler.cs
+++ b/WinFormsUI/Docking/DockContentHandler.cs
@@ -135,6 +135,16 @@ namespace WeifenLuo.WinFormsUI.Docking
             set { m_closeButtonVisible = value; }
         }
         
+        private static bool m_windowListButtonVisible = true;
+
+
+        public bool WindowListButtonVisible
+        {
+            get { return m_windowListButtonVisible; }
+
+            set { m_windowListButtonVisible = value; }
+        }
+		
         private DockState DefaultDockState
         {
             get

--- a/WinFormsUI/Docking/Strings.Designer.cs
+++ b/WinFormsUI/Docking/Strings.Designer.cs
@@ -214,6 +214,15 @@ namespace WeifenLuo.WinFormsUI.Docking {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Shows or hides the window list button of the content. This property does not function with System MDI Document Style..
+        /// </summary>
+        internal static string DockContent_WindowListButtonVisible_Description {
+            get {
+                return ResourceManager.GetString("DockContent_WindowListButtonVisible_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The provided value is out of range..
         /// </summary>
         internal static string DockContentHandler_AutoHidePortion_OutOfRange {

--- a/WinFormsUI/Docking/Strings.resx
+++ b/WinFormsUI/Docking/Strings.resx
@@ -351,6 +351,9 @@
   <data name="DockContent_CloseButtonVisible_Description" xml:space="preserve">
     <value>Shows or hides the close button of the content. This property does not function with System MDI Document Style.</value>
   </data>
+  <data name="DockContent_WindowListButtonVisible_Description" xml:space="preserve">
+    <value>Shows or hides the window list button of the content. This property does not function with System MDI Document Style.</value>
+  </data>
   <data name="DockPanel_DockPanelSkin" xml:space="preserve">
     <value>The visual skin to use when displaying the docked windows.</value>
   </data>

--- a/WinFormsUI/Docking/VS2005DockPaneCaption.cs
+++ b/WinFormsUI/Docking/VS2005DockPaneCaption.cs
@@ -52,12 +52,12 @@ namespace WeifenLuo.WinFormsUI.Docking
         }
 
         #region consts
-        private const int _TextGapTop = 2;
-        private const int _TextGapBottom = 0;
+        private const int _TextGapTop = 1;
+        private const int _TextGapBottom = 1;
         private const int _TextGapLeft = 3;
         private const int _TextGapRight = 3;
-        private const int _ButtonGapTop = 2;
-        private const int _ButtonGapBottom = 1;
+        private const int _ButtonGapTop = 1;
+        private const int _ButtonGapBottom = 2;
         private const int _ButtonGapBetween = 1;
         private const int _ButtonGapLeft = 1;
         private const int _ButtonGapRight = 2;

--- a/WinFormsUI/Docking/VS2005DockPaneStrip.cs
+++ b/WinFormsUI/Docking/VS2005DockPaneStrip.cs
@@ -134,7 +134,7 @@ namespace WeifenLuo.WinFormsUI.Docking
         private static string m_toolTipSelect;
         private static string m_toolTipClose;
         private bool m_closeButtonVisible = false;
-
+        private bool m_windowListButtonVisible = false;
         #endregion
 
         #region Properties
@@ -1300,6 +1300,8 @@ namespace WeifenLuo.WinFormsUI.Docking
                 rect.Y + rect.Height - 1 - DocumentIconGapBottom - DocumentIconHeight,
                 DocumentIconWidth, DocumentIconHeight);
             Rectangle rectText = rectIcon;
+            rectText.Height += 3;
+
             if (DockPane.DockPanel.ShowDocumentIcon)
             {
                 rectText.X += rectIcon.Width + DocumentIconGapRight;
@@ -1391,6 +1393,12 @@ namespace WeifenLuo.WinFormsUI.Docking
                 m_closeButtonVisible = DockPane.ActiveContent == null ? true : DockPane.ActiveContent.DockHandler.CloseButtonVisible;
                 ButtonClose.Visible = m_closeButtonVisible;
                 ButtonClose.RefreshChanges();
+
+                m_windowListButtonVisible = DockPane.ActiveContent == null
+                                                ? true
+                                                : DockPane.ActiveContent.DockHandler.WindowListButtonVisible;
+                ButtonWindowList.Visible = m_windowListButtonVisible;
+
                 ButtonWindowList.RefreshChanges();
             }
         }

--- a/WinFormsUI/Docking/VS2012LightDockPaneCaption.cs
+++ b/WinFormsUI/Docking/VS2012LightDockPaneCaption.cs
@@ -55,8 +55,8 @@ namespace WeifenLuo.WinFormsUI.Docking
         private const int _TextGapBottom = 2;
         private const int _TextGapLeft = 2;
         private const int _TextGapRight = 3;
-        private const int _ButtonGapTop = 2;
-        private const int _ButtonGapBottom = 1;
+        private const int _ButtonGapTop = 1;
+        private const int _ButtonGapBottom = 2;
         private const int _ButtonGapBetween = 1;
         private const int _ButtonGapLeft = 1;
         private const int _ButtonGapRight = 2;

--- a/WinFormsUI/Docking/VS2012LightDockPaneStrip.cs
+++ b/WinFormsUI/Docking/VS2012LightDockPaneStrip.cs
@@ -135,6 +135,7 @@ namespace WeifenLuo.WinFormsUI.Docking
         private static string m_toolTipClose;
         private bool m_closeButtonVisible = false;
         private Rectangle _activeClose;
+        private bool m_windowListButtonVisible = false;
 
         #endregion
 
@@ -1155,6 +1156,7 @@ namespace WeifenLuo.WinFormsUI.Docking
                 rect.Y + rect.Height - DocumentIconGapBottom - DocumentIconHeight,
                 DocumentIconWidth, DocumentIconHeight);
             Rectangle rectText = rectIcon;
+            rectText.Height += 1;
             if (DockPane.DockPanel.ShowDocumentIcon)
             {
                 rectText.X += rectIcon.Width + DocumentIconGapRight;
@@ -1287,6 +1289,12 @@ namespace WeifenLuo.WinFormsUI.Docking
                 m_closeButtonVisible = false;
                 ButtonClose.Visible = m_closeButtonVisible;
                 ButtonClose.RefreshChanges();
+
+                m_windowListButtonVisible = DockPane.ActiveContent == null
+                                                ? true
+                                                : DockPane.ActiveContent.DockHandler.WindowListButtonVisible;
+                ButtonWindowList.Visible = m_windowListButtonVisible;
+
                 ButtonWindowList.RefreshChanges();
             }
         }


### PR DESCRIPTION
Added the "WindowListButtonVisible" property to DockContent to hiding
the window list (down arrow) button on document tabs. Also, corrected
the vertical placement of text and icons on the tool bar windows for
both VS2005 and VS2012 themes. Please note that the new
WindowListButtonVisible property does not apply to the VS2003 theme,
which uses left/right arrows instead.
