### PR TITLE
DockPanel.Persistor / SaveAsXml: Use XmlWriter.Create

### DIFF
--- a/WinFormsUI/Docking/DockPanel.Persistor.cs
+++ b/WinFormsUI/Docking/DockPanel.Persistor.cs
@@ -232,10 +232,8 @@ namespace WeifenLuo.WinFormsUI.Docking
 
             public static void SaveAsXml(DockPanel dockPanel, Stream stream, Encoding encoding, bool upstream)
             {
-                XmlTextWriter xmlOut = new XmlTextWriter(stream, encoding);
-
-                // Use indenting for readability
-                xmlOut.Formatting = Formatting.Indented;
+				// Use indenting for readability
+				XmlWriter xmlOut = XmlWriter.Create(stream, new XmlWriterSettings() { Encoding = encoding, Indent = true });
 
                 if (!upstream)
                     xmlOut.WriteStartDocument();


### PR DESCRIPTION
Using 'XmlWriter.Create' prevent the underlying stream from beeing closed when the XmlWriter ist closed. For the FileStream used in the source file, isnt' a bug because the file is written well. But if you're like to write the output to a MemomryStream, you can't read the result, if the (underlying) MemoryStream has been closed.
