### PR TITLE
Fixed ActiveDocument property.

### DIFF
--- a/WinFormsUI/Docking/DockPanel.FocusManager.cs
+++ b/WinFormsUI/Docking/DockPanel.FocusManager.cs
@@ -350,7 +350,7 @@ namespace WeifenLuo.WinFormsUI.Docking
                     if (pane == null)
                         RefreshActiveWindow();
                 }
-                else if (msg == Win32.Msgs.WM_SETFOCUS)
+                else if (msg == Win32.Msgs.WM_SETFOCUS || msg == Win32.Msgs.WM_MDIACTIVATE)
                     RefreshActiveWindow();
             }
 


### PR DESCRIPTION
After the user presses Ctrl + Tab keys to change active document, `ActiveDocument` property returns previous content.  This patch will fix the problem.
