### PR TITLE
#237 Fix Show(DockPanel, Rectangle)

### DIFF
--- a/WinFormsUI/Docking/DockContentHandler.cs
+++ b/WinFormsUI/Docking/DockContentHandler.cs
@@ -855,8 +855,11 @@ namespace WeifenLuo.WinFormsUI.Docking
 
             DockPanel = dockPanel;
 
-            if (dockState == DockState.Float && FloatPane == null)
-                Pane = DockPanel.DockPaneFactory.CreateDockPane(Content, DockState.Float, true);
+            if (dockState == DockState.Float)
+            {
+                if (FloatPane == null)
+                    Pane = DockPanel.DockPaneFactory.CreateDockPane(Content, DockState.Float, true);
+            }
             else if (PanelPane == null)
             {
                 DockPane paneExisting = null;


### PR DESCRIPTION
If floating the content and a FloatPane exists, no need to set the Pane, it's already ready to go.  This is the proposed fix for #237.
