### PR TITLE
Fix memory leak if FocusManager is suspended/resumed after disposal

### DIFF
--- a/WinFormsUI/Docking/DockPanel.FocusManager.cs
+++ b/WinFormsUI/Docking/DockPanel.FocusManager.cs
@@ -122,7 +122,7 @@ namespace WeifenLuo.WinFormsUI.Docking
             [ThreadStatic]
             private static LocalWindowsHook sm_localWindowsHook;
 
-            private LocalWindowsHook.HookEventHandler m_hookEventHandler;
+            private readonly LocalWindowsHook.HookEventHandler m_hookEventHandler;
 
             public FocusManagerImpl(DockPanel dockPanel)
             {
@@ -307,14 +307,19 @@ namespace WeifenLuo.WinFormsUI.Docking
             private uint m_countSuspendFocusTracking = 0;
             public void SuspendFocusTracking()
             {
-                m_countSuspendFocusTracking++;
-                if (!Win32Helper.IsRunningOnMono)
-                    sm_localWindowsHook.HookInvoked -= m_hookEventHandler;
+                if (m_disposed)
+                    return;
+
+                if (m_countSuspendFocusTracking++ == 0)
+                {
+                    if (!Win32Helper.IsRunningOnMono)
+                        sm_localWindowsHook.HookInvoked -= m_hookEventHandler;
+                }
             }
 
             public void ResumeFocusTracking()
             {
-                if (m_countSuspendFocusTracking == 0)
+                if (m_disposed || m_countSuspendFocusTracking == 0)
                     return;
 
                 if (--m_countSuspendFocusTracking == 0)


### PR DESCRIPTION
Not sure why SuspendFocusTracking and ResumeFocusTracking are being called
after the FocusManager has been disposed, but I am seeing it happen. It can
then be left subscribed to the windows hook event.