### PR TITLE
Enable serialization of user attributes of a DockContent

### DIFF
--- a/DockSample/DummyDoc.cs
+++ b/DockSample/DummyDoc.cs
@@ -65,6 +65,21 @@ namespace DockSample
             return GetType().ToString() + "," + FileName + "," + Text;
         }
 
+        public override void Deserialize(System.Xml.XmlReader reader)
+        {
+            // Deserialize extra information.
+            string myUserValue = reader.GetAttribute("UserData");
+
+            base.Deserialize(reader);
+        }
+        public override void Serialize(System.Xml.XmlWriter writer)
+        {
+            // Serialize extra information.
+            writer.WriteAttributeString("UserData", "My user value");
+
+            base.Serialize(writer);
+        }
+
         private void menuItem2_Click(object sender, System.EventArgs e)
         {
             MessageBox.Show("This is to demostrate menu item has been successfully merged into the main form. Form Text=" + Text);

--- a/DockSample/MainForm.cs
+++ b/DockSample/MainForm.cs
@@ -34,6 +34,16 @@ namespace DockSample
             
             vS2012ToolStripExtender1.DefaultRenderer = _system;
             vS2012ToolStripExtender1.VS2012Renderer = _custom;
+
+            // Load/Save global user configurations.
+            dockPanel.OnLoadUserConfiguration += delegate(System.Xml.XmlReader reader)
+            {
+                string myGlobalUserValue = reader.GetAttribute("GlobalUserData");
+            };
+            dockPanel.OnSaveUserConfiguration += delegate(System.Xml.XmlWriter writer)
+            {
+                writer.WriteAttributeString("GlobalUserData", "My global user value");
+            };
         }
 
         #region Methods

--- a/WinFormsUI/Docking/DockContent.cs
+++ b/WinFormsUI/Docking/DockContent.cs
@@ -286,6 +286,13 @@ namespace WeifenLuo.WinFormsUI.Docking
         {
             this.OnDeactivate(e);
         }
+
+        public virtual void Deserialize(System.Xml.XmlReader reader)
+        {
+        }
+        public virtual void Serialize(System.Xml.XmlWriter writer)
+        {
+        }
         #endregion
 
         #region Events

--- a/WinFormsUI/Docking/DockPanel.Persistor.cs
+++ b/WinFormsUI/Docking/DockPanel.Persistor.cs
@@ -358,6 +358,9 @@ namespace WeifenLuo.WinFormsUI.Docking
                     }
                     xmlOut.WriteEndElement();	//	</FloatWindows>
 
+                    // Save global user configuration
+                    dockPanel.SaveUserConfigurationAsXml(xmlOut);
+
                     xmlOut.WriteEndElement();
 
                     if (!upstream)
@@ -579,6 +582,9 @@ namespace WeifenLuo.WinFormsUI.Docking
                         throw new ArgumentException(Strings.DockPanel_LoadFromXml_InvalidXmlFormat);
                     floatWindows = LoadFloatWindows(xmlIn);
 
+                    // Load global user configuration.
+                    dockPanel.LoadUserConfigurationFromXml(xmlIn);
+
                     if (closeStream)
                         xmlIn.Close();
                 }
@@ -797,5 +803,35 @@ namespace WeifenLuo.WinFormsUI.Docking
         {
             Persistor.LoadFromXml(this, stream, deserializeContent, closeStream);
         }
+
+        internal bool LoadUserConfigurationFromXml(System.Xml.XmlReader reader)
+        {
+            if (OnLoadUserConfiguration!=null && reader.NodeType!=XmlNodeType.EndElement && reader.Name=="UserConfigurations")
+            {
+                OnLoadUserConfiguration(reader);
+                return true;
+            }
+            return false;
+        }
+        /// <summary> Defines a delegate for deserialize global user data from the stream specified. </summary>
+        public delegate void LoadXmlUserConfigurationHandler(System.Xml.XmlReader reader);
+        /// <summary> Occurs when the DockPanel wants deserialize global user data. </summary>
+        public event LoadXmlUserConfigurationHandler OnLoadUserConfiguration;
+
+        internal bool SaveUserConfigurationAsXml(System.Xml.XmlWriter writer)
+        {
+            if (OnSaveUserConfiguration!=null)
+            {
+                writer.WriteStartElement("UserConfigurations");
+                OnSaveUserConfiguration(writer);
+                writer.WriteEndElement();
+                return true;
+            }
+            return false;
+        }
+        /// <summary> Defines a delegate for serialize global user data to the stream specified. </summary>
+        public delegate void SaveXmlUserConfigurationHandler(System.Xml.XmlWriter writer);
+        /// <summary> Occurs when the DockPanel wants serialize global user data. </summary>
+        public event SaveXmlUserConfigurationHandler OnSaveUserConfiguration;
     }
 }

--- a/WinFormsUI/Docking/Interfaces.cs
+++ b/WinFormsUI/Docking/Interfaces.cs
@@ -9,6 +9,8 @@ namespace WeifenLuo.WinFormsUI.Docking
         DockContentHandler DockHandler	{	get;	}
         void OnActivated(EventArgs e);
         void OnDeactivate(EventArgs e);
+        void Deserialize(System.Xml.XmlReader reader);
+        void Serialize(System.Xml.XmlWriter writer);
     }
 
     public interface INestedPanesContainer


### PR DESCRIPTION
This change enables the serialization of user attributes of a IDockContent interface.