### PR TITLE
Ignore invisible content panes when being dragged

### DIFF
--- a/WinFormsUI/Docking/DockContentHandler.cs
+++ b/WinFormsUI/Docking/DockContentHandler.cs
@@ -1093,18 +1093,18 @@ namespace WeifenLuo.WinFormsUI.Docking
                 if (!samePane)
                     Pane = pane;
 
-				int visiblePanes = 0;
-				int convertedIndex = 0;
-				while (visiblePanes <= contentIndex && convertedIndex < Pane.Contents.Count)
-				{
-					DockContent window = Pane.Contents[convertedIndex] as DockContent;
-					if (window != null && !window.IsHidden)
-						++visiblePanes;
+                int visiblePanes = 0;
+                int convertedIndex = 0;
+                while (visiblePanes <= contentIndex && convertedIndex < Pane.Contents.Count)
+                {
+                    DockContent window = Pane.Contents[convertedIndex] as DockContent;
+                    if (window != null && !window.IsHidden)
+                        ++visiblePanes;
 
-					++convertedIndex;
-				}
+                    ++convertedIndex;
+                }
 
-				contentIndex = Math.Min(Math.Max(0, convertedIndex-1), Pane.Contents.Count - 1);
+                contentIndex = Math.Min(Math.Max(0, convertedIndex-1), Pane.Contents.Count - 1);
 
                 if (contentIndex == -1 || !samePane)
                     pane.SetContentIndex(Content, contentIndex);

--- a/WinFormsUI/Docking/DockContentHandler.cs
+++ b/WinFormsUI/Docking/DockContentHandler.cs
@@ -1093,6 +1093,19 @@ namespace WeifenLuo.WinFormsUI.Docking
                 if (!samePane)
                     Pane = pane;
 
+				int visiblePanes = 0;
+				int convertedIndex = 0;
+				while (visiblePanes <= contentIndex && convertedIndex < Pane.Contents.Count)
+				{
+					DockContent window = Pane.Contents[convertedIndex] as DockContent;
+					if (window != null && !window.IsHidden)
+						++visiblePanes;
+
+					++convertedIndex;
+				}
+
+				contentIndex = Math.Min(Math.Max(0, convertedIndex-1), Pane.Contents.Count - 1);
+
                 if (contentIndex == -1 || !samePane)
                     pane.SetContentIndex(Content, contentIndex);
                 else

--- a/WinFormsUI/Docking/VS2003AutoHideStrip.cs
+++ b/WinFormsUI/Docking/VS2003AutoHideStrip.cs
@@ -477,6 +477,11 @@ namespace WeifenLuo.WinFormsUI.Docking
             return null;
         }
 
+        protected override Rectangle GetTabBounds(Tab tab)
+        {
+            return GetTabRectangle((TabVS2003)tab, true);
+        }
+
         /// <exclude/>
         protected internal override int MeasureHeight()
         {

--- a/WinFormsUI/Docking/VS2003DockPaneStrip.cs
+++ b/WinFormsUI/Docking/VS2003DockPaneStrip.cs
@@ -1039,6 +1039,11 @@ namespace WeifenLuo.WinFormsUI.Docking
             return -1;
         }
 
+        protected override Rectangle GetTabBounds(Tab tab)
+        {
+            return GetTabRectangle(Tabs.IndexOf(tab));
+        }
+
         /// <exclude/>
         protected override void OnMouseMove(MouseEventArgs e)
         {

--- a/WinFormsUI/Docking/VS2005AutoHideStrip.cs
+++ b/WinFormsUI/Docking/VS2005AutoHideStrip.cs
@@ -511,6 +511,13 @@ namespace WeifenLuo.WinFormsUI.Docking
             return null;
         }
 
+        protected override Rectangle GetTabBounds(Tab tab)
+        {
+            GraphicsPath path = GetTabOutline((TabVS2005)tab, true, true);
+            RectangleF bounds = path.GetBounds();
+            return new Rectangle((int)bounds.Left, (int)bounds.Top, (int)bounds.Width, (int)bounds.Height);
+        }
+
         protected internal override int MeasureHeight()
         {
             return Math.Max(ImageGapBottom +

--- a/WinFormsUI/Docking/VS2005DockPaneStrip.cs
+++ b/WinFormsUI/Docking/VS2005DockPaneStrip.cs
@@ -1490,6 +1490,13 @@ namespace WeifenLuo.WinFormsUI.Docking
             return -1;
         }
 
+        protected override Rectangle GetTabBounds(Tab tab)
+        {
+            GraphicsPath path = GetTabOutline(tab, true, false);
+            RectangleF rectangle = path.GetBounds();
+            return new Rectangle((int)rectangle.Left, (int)rectangle.Top, (int)rectangle.Width, (int)rectangle.Height);
+        }
+
         protected override void OnMouseHover(EventArgs e)
         {
             int index = HitTest(PointToClient(Control.MousePosition));

--- a/WinFormsUI/Docking/VS2012LightAutoHideStrip.cs
+++ b/WinFormsUI/Docking/VS2012LightAutoHideStrip.cs
@@ -514,6 +514,13 @@ namespace WeifenLuo.WinFormsUI.Docking
                 return null;
         }
 
+        protected override Rectangle GetTabBounds(Tab tab)
+        {
+            GraphicsPath path = GetTabOutline((TabVS2012Light)tab, true, true);
+            RectangleF bounds = path.GetBounds();
+            return new Rectangle((int)bounds.Left, (int)bounds.Top, (int)bounds.Width, (int)bounds.Height);
+        }
+
         protected Tab TabHitTest(Point ptMouse)
         {
             foreach (DockState state in DockStates)

--- a/WinFormsUI/Docking/VS2012LightDockPaneStrip.cs
+++ b/WinFormsUI/Docking/VS2012LightDockPaneStrip.cs
@@ -1391,6 +1391,13 @@ namespace WeifenLuo.WinFormsUI.Docking
             return -1;
         }
 
+        protected override Rectangle GetTabBounds(Tab tab)
+        {
+            GraphicsPath path = GetTabOutline(tab, true, false);
+            RectangleF rectangle = path.GetBounds();
+            return new Rectangle((int)rectangle.Left, (int)rectangle.Top, (int)rectangle.Width, (int)rectangle.Height);
+        }
+
         private Rectangle ActiveClose
         {
             get { return _activeClose; }

--- a/WinFormsUI/WinFormsUI.csproj
+++ b/WinFormsUI/WinFormsUI.csproj
@@ -34,6 +34,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Accessibility" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />


### PR DESCRIPTION
This also adds support for test automation systems. The problem with DPS is that custom rendered elements such as the tabs on the auto-hide bar are not detectable for external processes which uses the accessibility layer of microsoft.