### PR TITLE
Do not attempt to bring controls to the front if their zOrder is already correct

### DIFF
--- a/WinFormsUI/Docking/DockPanel.cs
+++ b/WinFormsUI/Docking/DockPanel.cs
@@ -664,9 +664,17 @@ namespace WeifenLuo.WinFormsUI.Docking
 
             AutoHideWindow.Bounds = GetAutoHideWindowBounds(AutoHideWindowRectangle);
 
-            DockWindows[DockState.Document].BringToFront();
-            AutoHideWindow.BringToFront();
-
+            // Index in the controls collection indicates existing zOrder. 
+            // docIndex = 0 && autoHideIndex == -1 is fine, as is autoHideIndex == 0 && docIndex == 1, othewise need to Re-order
+            // Re-ordering every time causes flicker.
+            var docIndex = Controls.IndexOf(DockWindows[DockState.Document]);
+            var autoHideIndex = Controls.IndexOf(AutoHideWindow);
+            if (autoHideIndex >= docIndex || docIndex > 1)
+            {
+                DockWindows[DockState.Document].BringToFront();
+                AutoHideWindow.BringToFront();
+            }
+ 
             base.OnLayout(levent);
 
             if (DocumentStyle == DocumentStyle.SystemMdi && MdiClientExists)


### PR DESCRIPTION
In DockPanel.OnLayout, the calls to BringToFront can cause flicker for controls inside an auto hide panel. Basically the handling of BringToFront ends up causing the content of the auto hide panel to be erased and redrawn. 

Most of the time, the zOrder is already correct for the items that need to be at the front, so the calls can be skipped. Checking zOrder is done by checking the index of the child controls in the parent 'Controls' collection - lowest numbers are on top.