### PR TITLE
Copy license.txt only if newer

### DIFF
--- a/WinFormsUI/WinFormsUI.csproj
+++ b/WinFormsUI/WinFormsUI.csproj
@@ -254,7 +254,7 @@
     <None Include="Docking\Resources\DockPane_OptionOverflow.png" />
     <None Include="dockpanelsuite.snk" />
     <None Include="license.txt">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Fix issue #224. This ensures that when there's nothing to do, MSBuild doesn't do anything.

--Tom