### PR TITLE
Removed focus content first when hiding

### DIFF
--- a/WinFormsUI/Docking/DockContentHandler.cs
+++ b/WinFormsUI/Docking/DockContentHandler.cs
@@ -506,6 +506,17 @@ namespace WeifenLuo.WinFormsUI.Docking
             m_visibleState = visibleState;
             m_dockState = isHidden ? DockState.Hidden : visibleState;
 
+            //Remove hidden content (shown content is added last so removal is done first to invert the operation)
+            bool hidingContent = (DockState == DockState.Hidden) || (DockState == DockState.Unknown) || DockHelper.IsDockStateAutoHide(DockState);
+            if (oldDockState != DockState)
+            {
+                if (hidingContent)
+                {
+                    if (!Win32Helper.IsRunningOnMono)
+                        DockPanel.ContentFocusManager.RemoveFromList(Content);
+                }
+            }
+
             if (visibleState == DockState.Unknown)
                 Pane = null;
             else
@@ -554,17 +565,11 @@ namespace WeifenLuo.WinFormsUI.Docking
 
             if (oldDockState != DockState)
             {
-                if (DockState == DockState.Hidden || DockState == DockState.Unknown ||
-                    DockHelper.IsDockStateAutoHide(DockState))
+                //Add content that is being shown
+                if (!hidingContent)
                 {
                     if (!Win32Helper.IsRunningOnMono)
-                    {
-                        DockPanel.ContentFocusManager.RemoveFromList(Content);
-                    }
-                }
-                else if (!Win32Helper.IsRunningOnMono)
-                {
-                    DockPanel.ContentFocusManager.AddToList(Content);
+                        DockPanel.ContentFocusManager.AddToList(Content);
                 }
 
                 ResetAutoHidePortion(oldDockState, DockState);


### PR DESCRIPTION
Moved the removal of focusable content to occur first since the content is added last when shown.  This prevents GiveUpFocus from re-activating the same content being hidden in the case where the content being hidden is the only content shown.

Steps to reproduce the original issue:
1) Use the DockingMDI style with multiple dock contents in a pane
2) Hide all dock content (hide the active content last)
3) Show all dock content
4) When the user switches between the dock content panes, the activated event will fire for all panes except when switching to/from the pane that was active before hiding.  