### PR TITLE
Fix font inheritance and cascading

### DIFF
--- a/WinFormsUI/Docking/DockContent.cs
+++ b/WinFormsUI/Docking/DockContent.cs
@@ -13,15 +13,6 @@ namespace WeifenLuo.WinFormsUI.Docking
         {
             m_dockHandler = new DockContentHandler(this, new GetPersistStringCallback(GetPersistString));
             m_dockHandler.DockStateChanged += new EventHandler(DockHandler_DockStateChanged);
-            //Suggested as a fix by bensty regarding form resize
-            this.ParentChanged += new EventHandler(DockContent_ParentChanged);
-        }
-
-        //Suggested as a fix by bensty regarding form resize
-        private void DockContent_ParentChanged(object Sender, EventArgs e)
-        {
-            if (this.Parent != null)
-                this.Font = this.Parent.Font;
         }
 
         private DockContentHandler m_dockHandler = null;

--- a/WinFormsUI/Docking/DockContentHandler.cs
+++ b/WinFormsUI/Docking/DockContentHandler.cs
@@ -747,7 +747,19 @@ namespace WeifenLuo.WinFormsUI.Docking
                 if (Form.MdiParent != DockPanel.ParentForm)
                 {
                     FlagClipWindow = true;
-                    Form.MdiParent = DockPanel.ParentForm;
+
+                    // The content form should inherit the font of the dock panel, not the font of
+                    // the dock panel's parent form. However, the content form's font value should
+                    // not be overwritten if it has been explicitly set to a non-default value.
+                    if (Form.Font == Control.DefaultFont)
+                    {
+                        Form.MdiParent = DockPanel.ParentForm;
+                        Form.Font = DockPanel.Font;
+                    }
+                    else
+                    {
+                        Form.MdiParent = DockPanel.ParentForm;
+                    }
                 }
             }
             else

--- a/WinFormsUI/Docking/FloatWindow.cs
+++ b/WinFormsUI/Docking/FloatWindow.cs
@@ -55,6 +55,8 @@ namespace WeifenLuo.WinFormsUI.Docking
             if (pane != null)
                 pane.FloatWindow = this;
 
+            Font = dockPanel.Font;
+
             ResumeLayout();
         }
 


### PR DESCRIPTION
I am using a non-default font in my application and I came across two closely related issues regarding font inheritance and cascading. The following steps can be used to reproduce the issues using the DockSample project.

Font inheritance:
  1. Open the `MainForm` form in the designer and change the font property to a distinctly non-default font. Refer to this as "Font&nbsp;A".
  2. Change the font property of the `dockPanel` control to a distinctly different font. Refer to this as "Font&nbsp;B".
  3. Run the application and use File->New to create a new document
  4. Observe the document content renders with "Font&nbsp;A" when the document is docked in the center document pane. I am not sure if this is the expected behavior or if it should render with "Font&nbsp;B".
  5. Observe the document content renders with "Font&nbsp;B" when docked to the left, right, top, or bottom. This is the behavior I would expect to happen.
  6. Observe the document content renders with the default font when the document is a undocked as a floating window. This is not the behavior I would expect. I am expecting this this to render with "Font&nbsp;B", the same as the docked content.

Font cascading:

  1. Leaving the changes above in place, open the `DummyDoc` form in the designer and change the form's font property to another distinct font. Refer to this as "Font&nbsp;C".
  2. Run the application again and observe the same behavior in steps 4-6 above. This is not the behavior I would expect in this case. I am expecting all scenarios to render with "Font&nbsp;C" because the `DummyDoc` form is explicitly setting the font property to "Font&nbsp;C". I would expect this to override any inherited font values.

The combined effect of these two issues is causing content in floating windows to always render with the system default font, regardless of the font settings on the main form, the dock panel, and the content forms. My proposed fix addresses these issues.

I thinks it's also worth mentioning that my proposed changes revert part of 33bc1ce that was committed back in January 2009. It's not clear to me what form resize issue is being referred to in the comments, but this doesn't seem like the correct solution. Nonetheless, I have only given a cursory look at the dockpanelsuite code. I am hoping someone with more expertise in this area can review my changes.