### PR TITLE
Enable Docking of DockContents similar as ToolBars do

### DIFF
--- a/DockSample/DockSample.csproj
+++ b/DockSample/DockSample.csproj
@@ -76,6 +76,12 @@
     <Compile Include="DummyTaskList.Designer.cs">
       <DependentUpon>DummyTaskList.cs</DependentUpon>
     </Compile>
+    <Compile Include="DummyToolBar.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="DummyToolBar.Designer.cs">
+      <DependentUpon>DummyToolBar.cs</DependentUpon>
+    </Compile>
     <Compile Include="DummyToolbox.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -130,6 +136,9 @@
     <EmbeddedResource Include="DummyTaskList.resx">
       <SubType>Designer</SubType>
       <DependentUpon>DummyTaskList.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="DummyToolBar.resx">
+      <DependentUpon>DummyToolBar.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="DummyToolbox.resx">
       <SubType>Designer</SubType>

--- a/DockSample/DummyToolBar.Designer.cs
+++ b/DockSample/DummyToolBar.Designer.cs
@@ -1,0 +1,187 @@
+﻿namespace DockSample
+{
+    partial class DummyToolBar
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(DummyToolBar));
+            this.toolStrip1 = new System.Windows.Forms.ToolStrip();
+            this.toolStripButton1 = new System.Windows.Forms.ToolStripButton();
+            this.toolStripButton2 = new System.Windows.Forms.ToolStripButton();
+            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStripDropDownButton1 = new System.Windows.Forms.ToolStripDropDownButton();
+            this.aToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.bToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.cToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripButton3 = new System.Windows.Forms.ToolStripButton();
+            this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+            this.toolStripButton4 = new System.Windows.Forms.ToolStripButton();
+            this.toolStripButton5 = new System.Windows.Forms.ToolStripButton();
+            this.toolStrip1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // toolStrip1
+            // 
+            this.toolStrip1.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
+            this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripButton1,
+            this.toolStripButton2,
+            this.toolStripSeparator1,
+            this.toolStripDropDownButton1,
+            this.toolStripButton3,
+            this.toolStripSeparator2,
+            this.toolStripButton4,
+            this.toolStripButton5});
+            this.toolStrip1.Location = new System.Drawing.Point(0, 0);
+            this.toolStrip1.Name = "toolStrip1";
+            this.toolStrip1.Size = new System.Drawing.Size(407, 25);
+            this.toolStrip1.TabIndex = 0;
+            this.toolStrip1.Text = "toolStrip1";
+            // 
+            // toolStripButton1
+            // 
+            this.toolStripButton1.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.toolStripButton1.Image = ((System.Drawing.Image)(resources.GetObject("toolStripButton1.Image")));
+            this.toolStripButton1.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolStripButton1.Name = "toolStripButton1";
+            this.toolStripButton1.Size = new System.Drawing.Size(23, 22);
+            this.toolStripButton1.Text = "toolStripButton1";
+            // 
+            // toolStripButton2
+            // 
+            this.toolStripButton2.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.toolStripButton2.Image = ((System.Drawing.Image)(resources.GetObject("toolStripButton2.Image")));
+            this.toolStripButton2.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolStripButton2.Name = "toolStripButton2";
+            this.toolStripButton2.Size = new System.Drawing.Size(23, 22);
+            this.toolStripButton2.Text = "toolStripButton2";
+            // 
+            // toolStripSeparator1
+            // 
+            this.toolStripSeparator1.Name = "toolStripSeparator1";
+            this.toolStripSeparator1.Size = new System.Drawing.Size(6, 25);
+            // 
+            // toolStripDropDownButton1
+            // 
+            this.toolStripDropDownButton1.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.toolStripDropDownButton1.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.aToolStripMenuItem,
+            this.bToolStripMenuItem,
+            this.cToolStripMenuItem});
+            this.toolStripDropDownButton1.Image = ((System.Drawing.Image)(resources.GetObject("toolStripDropDownButton1.Image")));
+            this.toolStripDropDownButton1.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolStripDropDownButton1.Name = "toolStripDropDownButton1";
+            this.toolStripDropDownButton1.Size = new System.Drawing.Size(29, 22);
+            this.toolStripDropDownButton1.Text = "toolStripDropDownButton1";
+            // 
+            // aToolStripMenuItem
+            // 
+            this.aToolStripMenuItem.Name = "aToolStripMenuItem";
+            this.aToolStripMenuItem.Size = new System.Drawing.Size(81, 22);
+            this.aToolStripMenuItem.Text = "a";
+            // 
+            // bToolStripMenuItem
+            // 
+            this.bToolStripMenuItem.Name = "bToolStripMenuItem";
+            this.bToolStripMenuItem.Size = new System.Drawing.Size(81, 22);
+            this.bToolStripMenuItem.Text = "b";
+            // 
+            // cToolStripMenuItem
+            // 
+            this.cToolStripMenuItem.Name = "cToolStripMenuItem";
+            this.cToolStripMenuItem.Size = new System.Drawing.Size(81, 22);
+            this.cToolStripMenuItem.Text = "c";
+            // 
+            // toolStripButton3
+            // 
+            this.toolStripButton3.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.toolStripButton3.Image = ((System.Drawing.Image)(resources.GetObject("toolStripButton3.Image")));
+            this.toolStripButton3.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolStripButton3.Name = "toolStripButton3";
+            this.toolStripButton3.Size = new System.Drawing.Size(23, 22);
+            this.toolStripButton3.Text = "toolStripButton3";
+            // 
+            // toolStripSeparator2
+            // 
+            this.toolStripSeparator2.Name = "toolStripSeparator2";
+            this.toolStripSeparator2.Size = new System.Drawing.Size(6, 25);
+            // 
+            // toolStripButton4
+            // 
+            this.toolStripButton4.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.toolStripButton4.Image = ((System.Drawing.Image)(resources.GetObject("toolStripButton4.Image")));
+            this.toolStripButton4.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolStripButton4.Name = "toolStripButton4";
+            this.toolStripButton4.Size = new System.Drawing.Size(23, 22);
+            this.toolStripButton4.Text = "toolStripButton4";
+            // 
+            // toolStripButton5
+            // 
+            this.toolStripButton5.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.toolStripButton5.Image = ((System.Drawing.Image)(resources.GetObject("toolStripButton5.Image")));
+            this.toolStripButton5.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolStripButton5.Name = "toolStripButton5";
+            this.toolStripButton5.Size = new System.Drawing.Size(23, 22);
+            this.toolStripButton5.Text = "toolStripButton5";
+            // 
+            // DummyToolBar
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(407, 32);
+            this.Controls.Add(this.toolStrip1);
+            this.DockAreas = ((WeifenLuo.WinFormsUI.Docking.DockAreas)((((((WeifenLuo.WinFormsUI.Docking.DockAreas.Float | WeifenLuo.WinFormsUI.Docking.DockAreas.DockLeft) 
+            | WeifenLuo.WinFormsUI.Docking.DockAreas.DockRight) 
+            | WeifenLuo.WinFormsUI.Docking.DockAreas.DockTop) 
+            | WeifenLuo.WinFormsUI.Docking.DockAreas.DockBottom) 
+            | WeifenLuo.WinFormsUI.Docking.DockAreas.ToolBar)));
+            this.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.Name = "DummyToolBar";
+            this.Text = "DummyToolBar";
+            this.toolStrip1.ResumeLayout(false);
+            this.toolStrip1.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.ToolStrip toolStrip1;
+        private System.Windows.Forms.ToolStripButton toolStripButton1;
+        private System.Windows.Forms.ToolStripButton toolStripButton2;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+        private System.Windows.Forms.ToolStripDropDownButton toolStripDropDownButton1;
+        private System.Windows.Forms.ToolStripMenuItem aToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem bToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem cToolStripMenuItem;
+        private System.Windows.Forms.ToolStripButton toolStripButton3;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
+        private System.Windows.Forms.ToolStripButton toolStripButton4;
+        private System.Windows.Forms.ToolStripButton toolStripButton5;
+    }
+}

--- a/DockSample/DummyToolBar.cs
+++ b/DockSample/DummyToolBar.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+using WeifenLuo.WinFormsUI.Docking;
+
+namespace DockSample
+{
+    public partial class DummyToolBar : DockContent
+    {
+        public DummyToolBar()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/DockSample/DummyToolBar.resx
+++ b/DockSample/DummyToolBar.resx
@@ -1,0 +1,214 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="toolStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="toolStripButton1.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
+        0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
+        bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
+        VzOOpHI7Jr376Hi9ogHqFIANO0/MmmmbmSmm9a8ze+I4MrNWAdjtoJgWcx+PSzg166yZZ8xM8XvXDix9
+        c4jIqFYAjoriBV9AhEPv1mH/sonogha0afbZMMZz+yreTGyhpusHwtNNCsA5U1zS4BLxzJIfg299qO32
+        Ir7UJtZfftyATqeT+8o2D8JSjQrAJblrncYL7ZJ2+bfaFnC/1S1NjL3diRat7qrO7wLRP3HjWsojBeCo
+        mDEo5mNjuweFGvjWg2EBhCbpkW78htSHHwRyNdmgAFzPEee2iFkzayy2OLXzT4gr6UdUnlXrullsxxQ+
+        kx0g8BTA3aZlButjSTyjODq/WcQcW/B/Je4OQhLvKQDnzN1mp0nnkvAhR8VuMzNrpm1mpjgkoVwB/v8D
+        TgDQASA1MVpwzwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="toolStripButton2.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
+        0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
+        bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
+        VzOOpHI7Jr376Hi9ogHqFIANO0/MmmmbmSmm9a8ze+I4MrNWAdjtoJgWcx+PSzg166yZZ8xM8XvXDix9
+        c4jIqFYAjoriBV9AhEPv1mH/sonogha0afbZMMZz+yreTGyhpusHwtNNCsA5U1zS4BLxzJIfg299qO32
+        Ir7UJtZfftyATqeT+8o2D8JSjQrAJblrncYL7ZJ2+bfaFnC/1S1NjL3diRat7qrO7wLRP3HjWsojBeCo
+        mDEo5mNjuweFGvjWg2EBhCbpkW78htSHHwRyNdmgAFzPEee2iFkzayy2OLXzT4gr6UdUnlXrullsxxQ+
+        kx0g8BTA3aZlButjSTyjODq/WcQcW/B/Je4OQhLvKQDnzN1mp0nnkvAhR8VuMzNrpm1mpjgkoVwB/v8D
+        TgDQASA1MVpwzwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="toolStripDropDownButton1.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
+        0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
+        bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
+        VzOOpHI7Jr376Hi9ogHqFIANO0/MmmmbmSmm9a8ze+I4MrNWAdjtoJgWcx+PSzg166yZZ8xM8XvXDix9
+        c4jIqFYAjoriBV9AhEPv1mH/sonogha0afbZMMZz+yreTGyhpusHwtNNCsA5U1zS4BLxzJIfg299qO32
+        Ir7UJtZfftyATqeT+8o2D8JSjQrAJblrncYL7ZJ2+bfaFnC/1S1NjL3diRat7qrO7wLRP3HjWsojBeCo
+        mDEo5mNjuweFGvjWg2EBhCbpkW78htSHHwRyNdmgAFzPEee2iFkzayy2OLXzT4gr6UdUnlXrullsxxQ+
+        kx0g8BTA3aZlButjSTyjODq/WcQcW/B/Je4OQhLvKQDnzN1mp0nnkvAhR8VuMzNrpm1mpjgkoVwB/v8D
+        TgDQASA1MVpwzwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="toolStripButton3.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
+        0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
+        bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
+        VzOOpHI7Jr376Hi9ogHqFIANO0/MmmmbmSmm9a8ze+I4MrNWAdjtoJgWcx+PSzg166yZZ8xM8XvXDix9
+        c4jIqFYAjoriBV9AhEPv1mH/sonogha0afbZMMZz+yreTGyhpusHwtNNCsA5U1zS4BLxzJIfg299qO32
+        Ir7UJtZfftyATqeT+8o2D8JSjQrAJblrncYL7ZJ2+bfaFnC/1S1NjL3diRat7qrO7wLRP3HjWsojBeCo
+        mDEo5mNjuweFGvjWg2EBhCbpkW78htSHHwRyNdmgAFzPEee2iFkzayy2OLXzT4gr6UdUnlXrullsxxQ+
+        kx0g8BTA3aZlButjSTyjODq/WcQcW/B/Je4OQhLvKQDnzN1mp0nnkvAhR8VuMzNrpm1mpjgkoVwB/v8D
+        TgDQASA1MVpwzwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="toolStripButton4.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
+        0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
+        bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
+        VzOOpHI7Jr376Hi9ogHqFIANO0/MmmmbmSmm9a8ze+I4MrNWAdjtoJgWcx+PSzg166yZZ8xM8XvXDix9
+        c4jIqFYAjoriBV9AhEPv1mH/sonogha0afbZMMZz+yreTGyhpusHwtNNCsA5U1zS4BLxzJIfg299qO32
+        Ir7UJtZfftyATqeT+8o2D8JSjQrAJblrncYL7ZJ2+bfaFnC/1S1NjL3diRat7qrO7wLRP3HjWsojBeCo
+        mDEo5mNjuweFGvjWg2EBhCbpkW78htSHHwRyNdmgAFzPEee2iFkzayy2OLXzT4gr6UdUnlXrullsxxQ+
+        kx0g8BTA3aZlButjSTyjODq/WcQcW/B/Je4OQhLvKQDnzN1mp0nnkvAhR8VuMzNrpm1mpjgkoVwB/v8D
+        TgDQASA1MVpwzwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="toolStripButton5.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
+        0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
+        bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
+        VzOOpHI7Jr376Hi9ogHqFIANO0/MmmmbmSmm9a8ze+I4MrNWAdjtoJgWcx+PSzg166yZZ8xM8XvXDix9
+        c4jIqFYAjoriBV9AhEPv1mH/sonogha0afbZMMZz+yreTGyhpusHwtNNCsA5U1zS4BLxzJIfg299qO32
+        Ir7UJtZfftyATqeT+8o2D8JSjQrAJblrncYL7ZJ2+bfaFnC/1S1NjL3diRat7qrO7wLRP3HjWsojBeCo
+        mDEo5mNjuweFGvjWg2EBhCbpkW78htSHHwRyNdmgAFzPEee2iFkzayy2OLXzT4gr6UdUnlXrullsxxQ+
+        kx0g8BTA3aZlButjSTyjODq/WcQcW/B/Je4OQhLvKQDnzN1mp0nnkvAhR8VuMzNrpm1mpjgkoVwB/v8D
+        TgDQASA1MVpwzwAAAABJRU5ErkJggg==
+</value>
+  </data>
+</root>

--- a/DockSample/MainForm.Designer.cs
+++ b/DockSample/MainForm.Designer.cs
@@ -81,6 +81,7 @@ namespace DockSample
             this.toolBarButtonToolbox = new System.Windows.Forms.ToolStripButton();
             this.toolBarButtonOutputWindow = new System.Windows.Forms.ToolStripButton();
             this.toolBarButtonTaskList = new System.Windows.Forms.ToolStripButton();
+            this.toolBarButtonToolBar = new System.Windows.Forms.ToolStripButton();
             this.toolBarButtonSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.toolBarButtonLayoutByCode = new System.Windows.Forms.ToolStripButton();
             this.toolBarButtonLayoutByXml = new System.Windows.Forms.ToolStripButton();
@@ -462,6 +463,7 @@ namespace DockSample
             this.toolBarButtonToolbox,
             this.toolBarButtonOutputWindow,
             this.toolBarButtonTaskList,
+            this.toolBarButtonToolBar,
             this.toolBarButtonSeparator2,
             this.toolBarButtonLayoutByCode,
             this.toolBarButtonLayoutByXml,
@@ -526,6 +528,16 @@ namespace DockSample
             this.toolBarButtonTaskList.Size = new System.Drawing.Size(23, 22);
             this.toolBarButtonTaskList.ToolTipText = "Task List";
             // 
+            // toolBarButtonToolBar
+            // 
+            this.toolBarButtonToolBar.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.toolBarButtonToolBar.Image = ((System.Drawing.Image)(resources.GetObject("toolBarButtonToolBar.Image")));
+            this.toolBarButtonToolBar.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolBarButtonToolBar.Name = "toolBarButtonToolBar";
+            this.toolBarButtonToolBar.Size = new System.Drawing.Size(23, 22);
+            this.toolBarButtonToolBar.ToolTipText = "ToolBar";
+            this.toolBarButtonToolBar.Click += new System.EventHandler(this.toolBarButtonToolBar_Click);
+            // 
             // toolBarButtonSeparator2
             // 
             this.toolBarButtonSeparator2.Name = "toolBarButtonSeparator2";
@@ -575,6 +587,7 @@ namespace DockSample
             // 
             this.vS2012ToolStripExtender1.DefaultRenderer = null;
             this.vS2012ToolStripExtender1.VS2012Renderer = null;
+            this.vS2012ToolStripExtender1.VS2013Renderer = null;
             // 
             // topBar
             // 
@@ -686,5 +699,6 @@ namespace DockSample
         private VSToolStripExtender vS2012ToolStripExtender1;
         private System.Windows.Forms.Panel topBar;
         private System.Windows.Forms.Panel bottomBar;
+        private System.Windows.Forms.ToolStripButton toolBarButtonToolBar;
     }
 }

--- a/DockSample/MainForm.cs
+++ b/DockSample/MainForm.cs
@@ -353,8 +353,8 @@ namespace DockSample
 
         private void toolBarButtonToolBar_Click(object sender, EventArgs e)
         {
-			DummyToolBar toolbar = new DummyToolBar();
-			toolbar.Show(dockPanel);
+            DummyToolBar toolbar = new DummyToolBar();
+            toolbar.Show(dockPanel);
         }
 
         private void menuItemOpen_Click(object sender, System.EventArgs e)

--- a/DockSample/MainForm.cs
+++ b/DockSample/MainForm.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Drawing;
 using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Reflection;
 using System.Windows.Forms;
@@ -117,6 +118,8 @@ namespace DockSample
                 return m_outputWindow;
             else if (persistString == typeof(DummyTaskList).ToString())
                 return m_taskList;
+            else if (persistString == typeof(DummyToolBar).ToString())
+                return new DummyToolBar();
             else
             {
                 // DummyDoc overrides GetPersistString to add extra information into persistString.
@@ -147,6 +150,15 @@ namespace DockSample
             m_toolbox.DockPanel = null;
             m_outputWindow.DockPanel = null;
             m_taskList.DockPanel = null;
+
+            // Close all DummyToolBars
+            foreach (IDockContent dockContent in new List<IDockContent>(dockPanel.Contents))
+            {
+                if (dockContent is DummyToolBar)
+                {
+                    dockContent.DockHandler.Close();
+                }
+            }
 
             // Close all other document windows
             CloseAllDocuments();
@@ -337,6 +349,12 @@ namespace DockSample
             }
             else
                 dummyDoc.Show(dockPanel);
+        }
+
+        private void toolBarButtonToolBar_Click(object sender, EventArgs e)
+        {
+			DummyToolBar toolbar = new DummyToolBar();
+			toolbar.Show(dockPanel);
         }
 
         private void menuItemOpen_Click(object sender, System.EventArgs e)

--- a/DockSample/MainForm.resx
+++ b/DockSample/MainForm.resx
@@ -131,7 +131,7 @@
         AAEAAAD/////AQAAAAAAAAAMAgAAAFdTeXN0ZW0uV2luZG93cy5Gb3JtcywgVmVyc2lvbj0yLjAuMC4w
         LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODkFAQAAACZTeXN0
         ZW0uV2luZG93cy5Gb3Jtcy5JbWFnZUxpc3RTdHJlYW1lcgEAAAAERGF0YQcCAgAAAAkDAAAADwMAAADY
-        DAAAAk1TRnQBSQFMAgEBCQEAAaQBAAGkAQABEAEAARABAAT/AQkBAAj/AUIBTQE2AQQGAAE2AQQCAAEo
+        DAAAAk1TRnQBSQFMAgEBCQEAAcQBAAHEAQABEAEAARABAAT/AQkBAAj/AUIBTQE2AQQGAAE2AQQCAAEo
         AwABQAMAATADAAEBAQABCAYAAQwYAAGAAgABgAMAAoABAAGAAwABgAEAAYABAAKAAgADwAEAAcAB3AHA
         AQAB8AHKAaYBAAEzBQABMwEAATMBAAEzAQACMwIAAxYBAAMcAQADIgEAAykBAANVAQADTQEAA0IBAAM5
         AQABgAF8Af8BAAJQAf8BAAGTAQAB1gEAAf8B7AHMAQABxgHWAe8BAAHWAucBAAGQAakBrQIAAf8BMwMA
@@ -192,6 +192,21 @@
     <value>383, 17</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="toolBarButtonToolBar.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIDSURBVDhPpZLrS5NhGMb3j4SWh0oRQVExD4gonkDpg4hG
+        YKxG6WBogkMZKgPNCEVJFBGdGETEvgwyO9DJE5syZw3PIlPEE9pgBCLZ5XvdMB8Ew8gXbl54nuf63dd9
+        0OGSnwCahxbPRNPAPMw9Xpg6ZmF46kZZ0xSKzJPIrhpDWsVnpBhGkKx3nAX8Pv7z1zg8OoY/cITdn4fw
+        bf/C0kYAN3Ma/w3gWfZL5kzTKBxjWyK2DftwI9tyMYCZKXbNHaD91bLYJrDXsYbrWfUKwJrPE9M2M1Oc
+        VzOOpHI7Jr376Hi9ogHqFIANO0/MmmmbmSmm9a8ze+I4MrNWAdjtoJgWcx+PSzg166yZZ8xM8XvXDix9
+        c4jIqFYAjoriBV9AhEPv1mH/sonogha0afbZMMZz+yreTGyhpusHwtNNCsA5U1zS4BLxzJIfg299qO32
+        Ir7UJtZfftyATqeT+8o2D8JSjQrAJblrncYL7ZJ2+bfaFnC/1S1NjL3diRat7qrO7wLRP3HjWsojBeCo
+        mDEo5mNjuweFGvjWg2EBhCbpkW78htSHHwRyNdmgAFzPEee2iFkzayy2OLXzT4gr6UdUnlXrullsxxQ+
+        kx0g8BTA3aZlButjSTyjODq/WcQcW/B/Je4OQhLvKQDnzN1mp0nnkvAhR8VuMzNrpm1mpjgkoVwB/v8D
+        TgDQASA1MVpwzwAAAABJRU5ErkJggg==
+</value>
+  </data>
   <data name="toolBarButtonDockPanelSkinDemo.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8

--- a/WinFormsUI/Docking/DockAreasEditor.cs
+++ b/WinFormsUI/Docking/DockAreasEditor.cs
@@ -17,6 +17,7 @@ namespace WeifenLuo.WinFormsUI.Docking
             private CheckBox checkBoxDockTop;
             private CheckBox checkBoxDockBottom;
             private CheckBox checkBoxDockFill;
+            private CheckBox checkBoxToolBar;
             private DockAreas m_oldDockAreas;
 
             public DockAreas DockAreas
@@ -37,6 +38,12 @@ namespace WeifenLuo.WinFormsUI.Docking
                     if (checkBoxDockFill.Checked)
                         dockAreas |= DockAreas.Document;
 
+                    if (checkBoxToolBar.Checked)
+                    {
+                        dockAreas |= (DockAreas.Float | DockAreas.ToolBar);
+                        dockAreas &= ~DockAreas.Document;
+                    }
+
                     if (dockAreas == 0)
                         return m_oldDockAreas;
                     else
@@ -52,6 +59,7 @@ namespace WeifenLuo.WinFormsUI.Docking
                 checkBoxDockTop = new CheckBox();
                 checkBoxDockBottom = new CheckBox();
                 checkBoxDockFill = new CheckBox();
+                checkBoxToolBar = new CheckBox();
 
                 SuspendLayout();
 
@@ -86,12 +94,21 @@ namespace WeifenLuo.WinFormsUI.Docking
                 checkBoxDockFill.Dock = System.Windows.Forms.DockStyle.Fill;
                 checkBoxDockFill.FlatStyle = FlatStyle.System;
 
+                checkBoxToolBar.Appearance = Appearance.Button;
+                checkBoxToolBar.Dock = DockStyle.Top;
+                checkBoxToolBar.Height = 24;
+                checkBoxToolBar.Text = Strings.DockAreaEditor_ToolBarCheckBoxText;
+                checkBoxToolBar.TextAlign = ContentAlignment.MiddleCenter;
+                checkBoxToolBar.FlatStyle = FlatStyle.System;
+                checkBoxToolBar.CheckedChanged += checkBoxToolBar_CheckedChanged;
+
                 this.Controls.AddRange(new Control[] {
                                                          checkBoxDockFill,
                                                          checkBoxDockBottom,
                                                          checkBoxDockTop,
                                                          checkBoxDockRight,
                                                          checkBoxDockLeft,
+                                                         checkBoxToolBar,
                                                          checkBoxFloat});
 
                 Size = new System.Drawing.Size(160, 144);
@@ -116,6 +133,21 @@ namespace WeifenLuo.WinFormsUI.Docking
                     checkBoxDockFill.Checked = true;
                 if ((dockAreas & DockAreas.Float) != 0)
                     checkBoxFloat.Checked = true;
+                if ((dockAreas & DockAreas.ToolBar) != 0)
+                    checkBoxToolBar.Checked = true;
+            }
+
+            private void checkBoxToolBar_CheckedChanged(object sender, EventArgs e)
+            {
+                if (checkBoxToolBar.Checked)
+                {
+                    checkBoxFloat.Checked = true;
+                    checkBoxDockFill.Enabled = checkBoxDockFill.Checked = false;
+                }
+                else
+                {
+                    checkBoxDockFill.Enabled = true;
+                }
             }
         }
 

--- a/WinFormsUI/Docking/DockContent.cs
+++ b/WinFormsUI/Docking/DockContent.cs
@@ -18,6 +18,16 @@ namespace WeifenLuo.WinFormsUI.Docking
             }
         }
 
+        protected override void OnFormClosing(FormClosingEventArgs e)
+        {
+            // Avoid that sometimes MainForm goes bottom in z-order position
+            if (e.CloseReason == CloseReason.UserClosing)
+            {
+                ActivateDockPanelForm();
+            }
+            base.OnFormClosing(e);
+        }
+
         private DockContentHandler m_dockHandler = null;
         [Browsable(false)]
         public DockContentHandler DockHandler
@@ -216,6 +226,17 @@ namespace WeifenLuo.WinFormsUI.Docking
         public new void Activate()
         {
             DockHandler.Activate();
+        }
+
+        internal void ActivateDockPanelForm()
+        {
+            Form mainForm = DockPanel != null ? DockPanel.ParentForm : null;
+            
+            if (mainForm != null)
+            {
+                mainForm.Activate();
+                mainForm.BringToFront();
+            }
         }
 
         public new void Hide()

--- a/WinFormsUI/Docking/DockContentHandler.cs
+++ b/WinFormsUI/Docking/DockContentHandler.cs
@@ -1126,10 +1126,10 @@ namespace WeifenLuo.WinFormsUI.Docking
 
                     switch (dockState)
                     {
-                        case DockState.DockLeft:   return DockStyle.Left;
-                        case DockState.DockTop:	   return DockStyle.Top;
-                        case DockState.DockRight:  return DockStyle.Right;
-                        case DockState.DockBottom: return DockStyle.Bottom;
+                        case DockState.DockLeft:    return DockStyle.Left;
+                        case DockState.DockTop:     return DockStyle.Top;
+                        case DockState.DockRight:   return DockStyle.Right;
+                        case DockState.DockBottom:  return DockStyle.Bottom;
                     }
                 }
                 return DockStyle.None;

--- a/WinFormsUI/Docking/DockPanel.FocusManager.cs
+++ b/WinFormsUI/Docking/DockPanel.FocusManager.cs
@@ -505,6 +505,24 @@ namespace WeifenLuo.WinFormsUI.Docking
             private void SetActiveDocument()
             {
                 IDockContent value = ActiveDocumentPane == null ? null : ActiveDocumentPane.ActiveContent;
+                
+                DockContent activeContent = DockPanel.ActiveContent as DockContent;
+
+                // Fix selection of floating documents
+                if (activeContent == null && DockPanel.ActiveDocument != null)
+                {
+                    activeContent = DockPanel.ActiveDocument as DockContent;
+                }
+                if (activeContent != null && (activeContent.DockAreas&DockAreas.Document) != 0
+                    &&
+                    activeContent.DockState != DockState.Document
+                    &&
+                    activeContent.DockState != DockState.Unknown
+                    &&
+                    DockPanel.Contents.Contains(activeContent))
+                {
+                    value = activeContent;
+                }
 
                 if (m_activeDocument == value)
                     return;

--- a/WinFormsUI/Docking/DockPanel.cs
+++ b/WinFormsUI/Docking/DockPanel.cs
@@ -50,6 +50,54 @@ namespace WeifenLuo.WinFormsUI.Docking
 
             SuspendLayout();
 
+            ToolStripPanel topToolStripPanel = new ToolStripPanel();
+            ToolStripPanel leftToolStripPanel = new ToolStripPanel();
+            ToolStripPanel rightToolStripPanel = new ToolStripPanel();
+            ToolStripPanel bottomToolStripPanel = new ToolStripPanel();
+
+            Size sz = this.ClientSize;
+            // 
+            // TopToolStripPanel
+            // 
+            topToolStripPanel.Dock = System.Windows.Forms.DockStyle.Top;
+            topToolStripPanel.Location = new System.Drawing.Point(0, 0);
+            topToolStripPanel.Name = "TopToolStripPanel";
+            topToolStripPanel.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            topToolStripPanel.RowMargin = new System.Windows.Forms.Padding(3, 0, 0, 0);
+            topToolStripPanel.Size = new System.Drawing.Size(sz.Width, 0);
+            // 
+            // LeftToolStripPanel
+            // 
+            leftToolStripPanel.Dock = System.Windows.Forms.DockStyle.Left;
+            leftToolStripPanel.Location = new System.Drawing.Point(0, 0);
+            leftToolStripPanel.Name = "LeftToolStripPanel";
+            leftToolStripPanel.Orientation = System.Windows.Forms.Orientation.Vertical;
+            leftToolStripPanel.RowMargin = new System.Windows.Forms.Padding(0, 3, 0, 0);
+            leftToolStripPanel.Size = new System.Drawing.Size(0, sz.Height);
+            // 
+            // RightToolStripPanel
+            // 
+            rightToolStripPanel.Dock = System.Windows.Forms.DockStyle.Right;
+            rightToolStripPanel.Location = new System.Drawing.Point(sz.Width, 0);
+            rightToolStripPanel.Name = "RightToolStripPanel";
+            rightToolStripPanel.Orientation = System.Windows.Forms.Orientation.Vertical;
+            rightToolStripPanel.RowMargin = new System.Windows.Forms.Padding(0, 3, 0, 0);
+            rightToolStripPanel.Size = new System.Drawing.Size(0, sz.Height);
+            // 
+            // BottomToolStripPanel
+            // 
+            bottomToolStripPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
+            bottomToolStripPanel.Location = new System.Drawing.Point(0, sz.Height);
+            bottomToolStripPanel.Name = "BottomToolStripPanel";
+            bottomToolStripPanel.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            bottomToolStripPanel.RowMargin = new System.Windows.Forms.Padding(3, 0, 0, 0);
+            bottomToolStripPanel.Size = new System.Drawing.Size(sz.Width, 0);
+
+            Controls.Add(bottomToolStripPanel);
+            Controls.Add(rightToolStripPanel);
+            Controls.Add(leftToolStripPanel);
+            Controls.Add(topToolStripPanel);
+
             m_autoHideWindow = Extender.AutoHideWindowFactory.CreateAutoHideWindow(this);
             m_autoHideWindow.Visible = false;
             m_autoHideWindow.ActiveContentChanged += m_autoHideWindow_ActiveContentChanged; 
@@ -63,6 +111,37 @@ namespace WeifenLuo.WinFormsUI.Docking
 
             m_dummyContent = new DockContent();
             ResumeLayout();
+        }
+
+        /// <summary> Get the specified DockStyle-ToolStripPanel </summary>
+        public ToolStripPanel GetToolStripPanel(DockStyle dockStyle)
+        {
+            foreach (Control control in this.Controls)
+            {
+                if (control is ToolStripPanel && control.Dock == dockStyle)
+                {
+                    return control as ToolStripPanel;
+                }
+            }
+            return null;
+        }
+        /// <summary> Get the full ToolStripPanel collection managed </summary>
+        public ToolStripPanel[] ToolStripPanels
+        {
+            get
+            {
+                int index = 0;
+                ToolStripPanel[] toolStripPanels = new ToolStripPanel[4];
+
+                foreach (Control control in this.Controls)
+                {
+                    if (control is ToolStripPanel)
+                    {
+                        toolStripPanels[index++] = control as ToolStripPanel;
+                    }
+                }
+                return toolStripPanels;
+            }
         }
 
         private Color m_BackColor;
@@ -697,13 +776,16 @@ namespace WeifenLuo.WinFormsUI.Docking
 
         protected override void OnPaint(PaintEventArgs e)
         {
+            if (DockBackColor != BackColor && DockBackColor.A > 0)
+            {
+                Graphics g = e.Graphics;
+                
+                using (SolidBrush bgBrush = new SolidBrush(DockBackColor))
+                {
+                    g.FillRectangle(bgBrush, ClientRectangle);
+                }
+            }
             base.OnPaint(e);
-
-            if (DockBackColor == BackColor) return;
-
-            Graphics g = e.Graphics;
-            SolidBrush bgBrush = new SolidBrush(DockBackColor);
-            g.FillRectangle(bgBrush, ClientRectangle);
         }
 
         internal void AddContent(IDockContent content)
@@ -908,6 +990,27 @@ namespace WeifenLuo.WinFormsUI.Docking
                 }
                 if (DockWindows[DockState.DockBottom].Visible)
                     rectDocumentBounds.Height -= DockWindows[DockState.DockBottom].Height;
+
+                ToolStripPanel toolStripPanel = null;
+
+                if ((toolStripPanel = this.GetToolStripPanel(DockStyle.Left)) != null && toolStripPanel.Visible && toolStripPanel.Width > 0)
+                {
+                    rectDocumentBounds.X += toolStripPanel.Width;
+                    rectDocumentBounds.Width -= toolStripPanel.Width;
+                }
+                if ((toolStripPanel = this.GetToolStripPanel(DockStyle.Right)) != null && toolStripPanel.Visible && toolStripPanel.Width > 0)
+                {
+                    rectDocumentBounds.Width -= toolStripPanel.Width;
+                }
+                if ((toolStripPanel = this.GetToolStripPanel(DockStyle.Top)) != null && toolStripPanel.Visible && toolStripPanel.Height > 0)
+                {
+                    rectDocumentBounds.Y += toolStripPanel.Height;
+                    rectDocumentBounds.Height -= toolStripPanel.Height;
+                }
+                if ((toolStripPanel = this.GetToolStripPanel(DockStyle.Bottom)) != null && toolStripPanel.Visible && toolStripPanel.Height > 0)
+                {
+                    rectDocumentBounds.Height -= toolStripPanel.Height;
+                }
 
                 return rectDocumentBounds;
 

--- a/WinFormsUI/Docking/DockToolStrip.cs
+++ b/WinFormsUI/Docking/DockToolStrip.cs
@@ -51,7 +51,7 @@ namespace WeifenLuo.WinFormsUI.Docking
                 }
             }
             base.OnMouseMove(e);
-		}
+        }
 
         /// <summary> Original OrientationStyle value. </summary>
         private readonly DockStyle m_originalOrientationStyle = DockStyle.None;

--- a/WinFormsUI/Docking/DockToolStrip.cs
+++ b/WinFormsUI/Docking/DockToolStrip.cs
@@ -1,0 +1,175 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Windows.Forms;
+using System.Drawing;
+
+namespace WeifenLuo.WinFormsUI.Docking
+{
+    /// <summary> Host manager of a ToolStrip for Docking </summary>
+    class DockToolStrip : ToolStrip
+    {
+        /// <summary> Creates a new DockToolStrip object </summary>
+        public DockToolStrip(ToolStripPanel ownerPanel, DockContent dockContent)
+        {
+            this.DockContent = dockContent;
+            this.Items.Add( new ToolStripContainerPanel(dockContent) );
+            this.ClientSize = dockContent.Size;
+            this.MinimumSize = this.Size;
+            
+            if (dockContent.Controls.Count == 1)
+            {
+                m_originalOrientationStyle = this.OrientationStyle;
+                OrientationStyle = ownerPanel.Orientation == Orientation.Vertical ? DockStyle.Left : DockStyle.Top;
+            }
+            Label label = new Label();
+            label.Name = "VirtualBnd";
+            label.Text = string.Empty;
+            label.AutoSize = true;
+            label.Location = new Point(this.ClientSize.Width - 3, this.ClientSize.Height - 3);
+            label.Anchor = AnchorStyles.Right | AnchorStyles.Bottom;
+            dockContent.Controls.Add(label);
+        }
+        /// <summary> Reference to the DockContent managed </summary>
+        public readonly DockContent DockContent;
+
+        protected override void OnMouseMove(MouseEventArgs e)
+        {
+            if (m_beginDrag && Parent is ToolStripPanel)
+            {
+                ToolStripPanel toolStripPanel = Parent as ToolStripPanel;
+                DockPanel dockPanel = DockContent.DockPanel;
+
+                if (dockPanel != null)
+                {
+                    Point ptMouse = Control.MousePosition;
+                    Point pt = dockPanel.PointToClient(ptMouse);
+
+                    Rectangle bounds = toolStripPanel.Bounds;
+                    bounds.Inflate(8, 8);
+                    if (!bounds.Contains(pt)) dockPanel.BeginDrag(DockContent.Pane.FloatWindow);
+                }
+            }
+            base.OnMouseMove(e);
+		}
+
+        /// <summary> Original OrientationStyle value. </summary>
+        private readonly DockStyle m_originalOrientationStyle = DockStyle.None;
+
+        protected override void OnBeginDrag(EventArgs e)
+        {
+            m_beginDrag = true;
+            base.OnBeginDrag(e);
+        }
+        protected override void OnEndDrag(EventArgs e)
+        {
+            m_beginDrag = false;
+
+            if (Parent is ToolStripPanel)
+            {
+                ToolStripPanel toolStripPanel = Parent as ToolStripPanel;
+                DockPanel dockPanel = DockContent.DockPanel;
+
+                if (dockPanel != null)
+                {
+                    Point ptMouse = Control.MousePosition;
+                    Point pt = dockPanel.PointToClient(ptMouse);
+
+                    bool isStripContained = false;
+
+                    foreach (ToolStripPanel panel in dockPanel.ToolStripPanels)
+                    {
+                        if (panel.Bounds.Contains(pt))
+                        {
+                            isStripContained = true;
+                            break;
+                        }
+                    }
+                    if (!isStripContained)
+                    {
+                        for (int i = DockContent.Controls.Count - 1; i >= 0; i--)
+                        {
+                            Control c = DockContent.Controls[i];
+                            if (c is Label && c.Name == "VirtualBnd") { DockContent.Controls.Remove(c); break; }
+                        }
+                        DockStyle layoutSyle = OrientationStyle;
+                        if (m_originalOrientationStyle != DockStyle.None) OrientationStyle = m_originalOrientationStyle;
+                        this.Visible = false;
+                        this.Items.RemoveAt(0);
+                        toolStripPanel.Controls.Remove(this);
+
+                        this.DockContent.DockHandler.SetDockState(DockState.Float, false);
+                        DockPane currentPane = this.DockContent.Pane;
+
+                        FloatWindow floatWindow = currentPane.FloatWindow;
+                        floatWindow.NestedPanes.Remove(currentPane);
+                        floatWindow.Location = ptMouse;
+                        if (layoutSyle == DockStyle.Left || layoutSyle == DockStyle.Right)
+                            floatWindow.Size = new Size(floatWindow.Height, floatWindow.Width + SystemInformation.ToolWindowCaptionHeight);
+                        else
+                            floatWindow.Size = new Size(floatWindow.Width, floatWindow.Height + SystemInformation.ToolWindowCaptionHeight);
+
+                        currentPane.FloatWindow = floatWindow;
+                        floatWindow.Visible = true;
+                    }
+                }
+            }
+            base.OnEndDrag(e);
+        }
+        private bool m_beginDrag = false;
+        
+        /// <summary> Gets or sets the OrientationStyle </summary>
+        private DockStyle OrientationStyle
+        {
+            get
+            {
+                foreach (Control control in DockContent.Controls)
+                {
+                    if (control is ToolBar)
+                    {
+                        ToolBar toolbar = control as ToolBar;
+                        return toolbar.Dock;
+                    }
+                    else
+                    if (control is ToolStrip)
+                    {
+                        ToolStrip toolStrip = control as ToolStrip;
+                        return toolStrip.LayoutStyle == ToolStripLayoutStyle.VerticalStackWithOverflow ?  DockStyle.Left : DockStyle.Top;
+                    }
+                }
+                return DockStyle.None;
+            }
+            set
+            {
+                foreach (Control control in DockContent.Controls)
+                {
+                    if (control is ToolBar)
+                    {
+                        ToolBar toolbar = control as ToolBar;
+                        toolbar.Dock = value;
+                    }
+                    else
+                    if (control is ToolStrip)
+                    {
+                        ToolStrip toolStrip = control as ToolStrip;
+                        toolStrip.LayoutStyle = value == DockStyle.Left || value == DockStyle.Right ? ToolStripLayoutStyle.VerticalStackWithOverflow : ToolStripLayoutStyle.HorizontalStackWithOverflow;
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary> Host manager for a ToolStripPanel owner of a DockContent </summary>
+    class ToolStripContainerPanel : ToolStripControlHost
+    {
+        /// <summary> Creates a new ToolStripContainerPanel object </summary>
+        public ToolStripContainerPanel(DockContent dockContent) : base(dockContent)
+        {
+        }
+        /// <summary> Returns the DockContent managed </summary>
+        public DockContent Content
+        {
+            get	{ return base.Control as DockContent; }
+        }
+    }
+}

--- a/WinFormsUI/Docking/DockUtils.cs
+++ b/WinFormsUI/Docking/DockUtils.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Windows.Forms;
+using System.Drawing;
+
+namespace WeifenLuo.WinFormsUI.Docking
+{
+    /// <summary> Docking utility class </summary>
+    static class DockUtils
+    {
+        /// <summary> Check whether the specified object contains a DockContent with ToolBar style </summary>
+        public static bool ContainsToolBar(IDockDragSource checkObject)
+        {
+            if (checkObject == null)
+                return false;
+
+            if (checkObject is DockPane)
+            {
+                foreach (DockContent content in (checkObject as DockPane).Contents)
+                {
+                    if ((content.DockAreas&DockAreas.ToolBar) != 0) return true;
+                }
+            }
+            else
+            if (checkObject is FloatWindow)
+            {
+                foreach (DockPane pane in (checkObject as FloatWindow).NestedPanes)
+                {
+                    foreach (DockContent content in pane.Contents)
+                    {
+                        if ((content.DockAreas&DockAreas.ToolBar) != 0) return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        /// <summary> Search the ToolStrip owner of the specified DockContent </summary>
+        public static ToolStrip FindToolStrip(DockContent dockContent)
+	    {
+            foreach (ToolStripPanel toolStripPanel in dockContent.DockPanel.ToolStripPanels)
+            {
+                foreach (ToolStrip toolStrip in toolStripPanel.Controls)
+                {
+                    foreach (ToolStripItem toolStripItem in toolStrip.Items)
+                    {
+                        if (toolStripItem is ToolStripContainerPanel && (toolStripItem as ToolStripContainerPanel).Content == dockContent)
+                        {
+                            return toolStrip;
+                        }
+                    }
+                }
+            }
+		    return null;
+	    }
+        
+        /// <summary> Creates a new ToolStrip for the specified DockContent </summary>
+        public static ToolStrip MakeToolStrip(ToolStripPanel ownerPanel, DockContent dockContent, Point location, bool perfomLayout)
+        {
+            DockState dockState = GetDockStatePanel(ownerPanel);
+            if (perfomLayout) ownerPanel.SuspendLayout();
+            
+            DockToolStrip toolStrip = new DockToolStrip(ownerPanel, dockContent);
+            toolStrip.Location = location;
+            
+            FloatWindow floatWindow = dockContent.Pane.FloatWindow;
+            floatWindow.Location = new Point(5000, 5000);
+            floatWindow.Visible = false;
+
+            dockContent.DockHandler.SetDockState(dockState, true);
+            ownerPanel.Controls.Add(toolStrip);
+
+            if (perfomLayout) 
+            {
+                dockContent.ActivateDockPanelForm();
+                ownerPanel.ResumeLayout(true);
+            }
+            return toolStrip;
+	    }
+        
+        /// <summary> Returns the ToolStripPanel for the specified IDockDragSource </summary>
+        public static ToolStripPanel ShouldToolStripPanelVisible(IDockDragSource checkObject, out DockContent currentContent)
+        {
+            currentContent = null;
+            
+            if (ContainsToolBar(checkObject) && checkObject is FloatWindow)
+            {
+                FloatWindow floatWindow = (FloatWindow)checkObject;
+                if ((currentContent = GetFirstContent(floatWindow)) == null) return null;
+
+                DockPanel dockPanel = floatWindow.DockPanel;
+                Point point = dockPanel.PointToClient(Control.MousePosition);
+                Rectangle rect = dockPanel.DockArea;
+                if (!rect.Contains(point)) return null;
+                
+                int splitterSize = 3 * Measures.SplitterSize;
+                Rectangle rectDock = new Rectangle(rect.Left + splitterSize, rect.Top + splitterSize, rect.Width - 2 * splitterSize, rect.Height - 2 * splitterSize);
+
+			    if ((currentContent.DockAreas&DockAreas.DockLeft) != 0)
+                {
+                    ToolStripPanel toolStripPanel = dockPanel.GetToolStripPanel(DockStyle.Left);
+                    if (toolStripPanel.Bounds.Contains(point) || (toolStripPanel.Bounds.Width == 0 && point.X < rectDock.Left)) return toolStripPanel;
+                }
+                if ((currentContent.DockAreas&DockAreas.DockRight) != 0)
+                {
+                    ToolStripPanel toolStripPanel = dockPanel.GetToolStripPanel(DockStyle.Right);
+                    if (toolStripPanel.Bounds.Contains(point) || (toolStripPanel.Bounds.Width == 0 && point.X > rectDock.Right)) return toolStripPanel;
+                }
+                if ((currentContent.DockAreas&DockAreas.DockTop) != 0)
+                {
+                    ToolStripPanel toolStripPanel = dockPanel.GetToolStripPanel(DockStyle.Top);
+                    if (toolStripPanel.Bounds.Contains(point) || (toolStripPanel.Bounds.Height == 0 && point.Y < rectDock.Top)) return toolStripPanel;
+                }
+                if ((currentContent.DockAreas&DockAreas.DockBottom) != 0)
+                {
+                    ToolStripPanel toolStripPanel = dockPanel.GetToolStripPanel(DockStyle.Bottom);
+                    if (toolStripPanel.Bounds.Contains(point) || (toolStripPanel.Bounds.Height == 0 && point.Y > rectDock.Bottom)) return toolStripPanel;
+                }
+            }
+            return null;
+        }
+        /// <summary> Returns the ToolStripPanel for the specified IDockDragSource </summary>
+        public static ToolStripPanel ShouldToolStripPanelVisible(IDockDragSource checkObject)
+        {
+            DockContent currentContent;
+            return ShouldToolStripPanelVisible(checkObject, out currentContent);
+        }
+
+        /// <summary> Returns the first DockContent contained in the specified FloatWindow </summary>
+        private static DockContent GetFirstContent(FloatWindow floatWindow)
+        {
+            foreach (DockPane pane in floatWindow.NestedPanes)
+            {
+                foreach (DockContent content in pane.Contents)
+                {
+                    return content;
+                }
+            }
+            return null;
+	    }
+
+        /// <summary> Returns the DockState for the specified ToolStripPanel </summary>
+        private static DockState GetDockStatePanel(ToolStripPanel toolStripPanel)
+        {
+            switch (toolStripPanel.Dock)
+            {
+                case DockStyle.Left:    return DockState.DockLeft;
+                case DockStyle.Top:     return DockState.DockTop;
+                case DockStyle.Right:   return DockState.DockRight;
+                case DockStyle.Bottom:  return DockState.DockBottom;
+            }
+            return DockState.Unknown;
+        }
+    }
+}

--- a/WinFormsUI/Docking/DockUtils.cs
+++ b/WinFormsUI/Docking/DockUtils.cs
@@ -38,7 +38,7 @@ namespace WeifenLuo.WinFormsUI.Docking
 
         /// <summary> Search the ToolStrip owner of the specified DockContent </summary>
         public static ToolStrip FindToolStrip(DockContent dockContent)
-	    {
+        {
             foreach (ToolStripPanel toolStripPanel in dockContent.DockPanel.ToolStripPanels)
             {
                 foreach (ToolStrip toolStrip in toolStripPanel.Controls)
@@ -52,8 +52,8 @@ namespace WeifenLuo.WinFormsUI.Docking
                     }
                 }
             }
-		    return null;
-	    }
+            return null;
+        }
         
         /// <summary> Creates a new ToolStrip for the specified DockContent </summary>
         public static ToolStrip MakeToolStrip(ToolStripPanel ownerPanel, DockContent dockContent, Point location, bool perfomLayout)
@@ -77,7 +77,7 @@ namespace WeifenLuo.WinFormsUI.Docking
                 ownerPanel.ResumeLayout(true);
             }
             return toolStrip;
-	    }
+        }
         
         /// <summary> Returns the ToolStripPanel for the specified IDockDragSource </summary>
         public static ToolStripPanel ShouldToolStripPanelVisible(IDockDragSource checkObject, out DockContent currentContent)
@@ -97,7 +97,7 @@ namespace WeifenLuo.WinFormsUI.Docking
                 int splitterSize = 3 * Measures.SplitterSize;
                 Rectangle rectDock = new Rectangle(rect.Left + splitterSize, rect.Top + splitterSize, rect.Width - 2 * splitterSize, rect.Height - 2 * splitterSize);
 
-			    if ((currentContent.DockAreas&DockAreas.DockLeft) != 0)
+                if ((currentContent.DockAreas&DockAreas.DockLeft) != 0)
                 {
                     ToolStripPanel toolStripPanel = dockPanel.GetToolStripPanel(DockStyle.Left);
                     if (toolStripPanel.Bounds.Contains(point) || (toolStripPanel.Bounds.Width == 0 && point.X < rectDock.Left)) return toolStripPanel;
@@ -138,7 +138,7 @@ namespace WeifenLuo.WinFormsUI.Docking
                 }
             }
             return null;
-	    }
+        }
 
         /// <summary> Returns the DockState for the specified ToolStripPanel </summary>
         private static DockState GetDockStatePanel(ToolStripPanel toolStripPanel)

--- a/WinFormsUI/Docking/Enums.cs
+++ b/WinFormsUI/Docking/Enums.cs
@@ -14,7 +14,8 @@ namespace WeifenLuo.WinFormsUI.Docking
         DockRight = 4,
         DockTop = 8,
         DockBottom = 16,
-        Document = 32
+        Document = 32,
+        ToolBar = 64
     }
 
     public enum DockState
@@ -30,7 +31,8 @@ namespace WeifenLuo.WinFormsUI.Docking
         DockLeft = 8,
         DockBottom = 9,
         DockRight = 10,
-        Hidden = 11
+        Hidden = 11,
+        ToolBar = 12
     }
 
     public enum DockAlignment

--- a/WinFormsUI/Docking/FloatWindow.cs
+++ b/WinFormsUI/Docking/FloatWindow.cs
@@ -40,8 +40,15 @@ namespace WeifenLuo.WinFormsUI.Docking
             SuspendLayout();
             if (boundsSpecified)
             {
+                // Clamp to working area
+                if (bounds.Left<0) bounds.Offset(-bounds.Left, 0);
+                if (bounds.Top<0) bounds.Offset(0, -bounds.Top);
+                Rectangle screenRect = Screen.PrimaryScreen.WorkingArea;
+                if (bounds.Right>screenRect.Width) bounds.Offset(screenRect.Width-bounds.Right,0);
+                if (bounds.Bottom>screenRect.Height) bounds.Offset(0,screenRect.Height-bounds.Bottom);
+
                 Bounds = bounds;
-                StartPosition = FormStartPosition.Manual;
+                StartPosition = bounds.Location.IsEmpty ? FormStartPosition.CenterParent : FormStartPosition.Manual;
             }
             else
             {
@@ -361,6 +368,9 @@ namespace WeifenLuo.WinFormsUI.Docking
                 return false;
 
             if (pane.FloatWindow == this)
+                return false;
+            
+            if (DockUtils.ContainsToolBar(this) || DockUtils.ContainsToolBar(pane.FloatWindow)) 
                 return false;
 
             return true;

--- a/WinFormsUI/Docking/Strings.Designer.cs
+++ b/WinFormsUI/Docking/Strings.Designer.cs
@@ -106,6 +106,15 @@ namespace WeifenLuo.WinFormsUI.Docking {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to (ToolBar).
+        /// </summary>
+        internal static string DockAreaEditor_ToolBarCheckBoxText {
+            get {
+                return ResourceManager.GetString("DockAreaEditor_ToolBarCheckBoxText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Determines if end user drag and drop docking is allowed..
         /// </summary>
         internal static string DockContent_AllowEndUserDocking_Description {

--- a/WinFormsUI/Docking/Strings.resx
+++ b/WinFormsUI/Docking/Strings.resx
@@ -129,6 +129,9 @@
   <data name="DockAreaEditor_FloatCheckBoxText" xml:space="preserve">
     <value>(Float)</value>
   </data>
+  <data name="DockAreaEditor_ToolBarCheckBoxText" xml:space="preserve">
+    <value>(ToolBar)</value>
+  </data>
   <data name="DockContent_AllowEndUserDocking_Description" xml:space="preserve">
     <value>Determines if end user drag and drop docking is allowed.</value>
   </data>

--- a/WinFormsUI/ThemeVS2005Multithreading/Strings.Designer.cs
+++ b/WinFormsUI/ThemeVS2005Multithreading/Strings.Designer.cs
@@ -106,6 +106,15 @@ namespace WeifenLuo.WinFormsUI.Docking {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to (ToolBar).
+        /// </summary>
+        internal static string DockAreaEditor_ToolBarCheckBoxText {
+            get {
+                return ResourceManager.GetString("DockAreaEditor_ToolBarCheckBoxText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Determines if end user drag and drop docking is allowed..
         /// </summary>
         internal static string DockContent_AllowEndUserDocking_Description {

--- a/WinFormsUI/ThemeVS2005Multithreading/Strings.resx
+++ b/WinFormsUI/ThemeVS2005Multithreading/Strings.resx
@@ -129,6 +129,9 @@
   <data name="DockAreaEditor_FloatCheckBoxText" xml:space="preserve">
     <value>(Float)</value>
   </data>
+  <data name="DockAreaEditor_ToolBarCheckBoxText" xml:space="preserve">
+    <value>(ToolBar)</value>
+  </data>
   <data name="DockContent_AllowEndUserDocking_Description" xml:space="preserve">
     <value>Determines if end user drag and drop docking is allowed.</value>
   </data>

--- a/WinFormsUI/ThemeVS2012Light/Strings.Designer.cs
+++ b/WinFormsUI/ThemeVS2012Light/Strings.Designer.cs
@@ -106,6 +106,15 @@ namespace WeifenLuo.WinFormsUI.ThemeVS2012Light {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to (ToolBar).
+        /// </summary>
+        internal static string DockAreaEditor_ToolBarCheckBoxText {
+            get {
+                return ResourceManager.GetString("DockAreaEditor_ToolBarCheckBoxText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Determines if end user drag and drop docking is allowed..
         /// </summary>
         internal static string DockContent_AllowEndUserDocking_Description {

--- a/WinFormsUI/ThemeVS2012Light/Strings.resx
+++ b/WinFormsUI/ThemeVS2012Light/Strings.resx
@@ -129,6 +129,9 @@
   <data name="DockAreaEditor_FloatCheckBoxText" xml:space="preserve">
     <value>(Float)</value>
   </data>
+  <data name="DockAreaEditor_ToolBarCheckBoxText" xml:space="preserve">
+    <value>(ToolBar)</value>
+  </data>
   <data name="DockContent_AllowEndUserDocking_Description" xml:space="preserve">
     <value>Determines if end user drag and drop docking is allowed.</value>
   </data>

--- a/WinFormsUI/ThemeVS2013Blue/Strings.Designer.cs
+++ b/WinFormsUI/ThemeVS2013Blue/Strings.Designer.cs
@@ -106,6 +106,15 @@ namespace WeifenLuo.WinFormsUI.ThemeVS2013Blue {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to (ToolBar).
+        /// </summary>
+        internal static string DockAreaEditor_ToolBarCheckBoxText {
+            get {
+                return ResourceManager.GetString("DockAreaEditor_ToolBarCheckBoxText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Determines if end user drag and drop docking is allowed..
         /// </summary>
         internal static string DockContent_AllowEndUserDocking_Description {

--- a/WinFormsUI/ThemeVS2013Blue/Strings.resx
+++ b/WinFormsUI/ThemeVS2013Blue/Strings.resx
@@ -129,6 +129,9 @@
   <data name="DockAreaEditor_FloatCheckBoxText" xml:space="preserve">
     <value>(Float)</value>
   </data>
+  <data name="DockAreaEditor_ToolBarCheckBoxText" xml:space="preserve">
+    <value>(ToolBar)</value>
+  </data>
   <data name="DockContent_AllowEndUserDocking_Description" xml:space="preserve">
     <value>Determines if end user drag and drop docking is allowed.</value>
   </data>

--- a/WinFormsUI/WinFormsUI.csproj
+++ b/WinFormsUI/WinFormsUI.csproj
@@ -50,6 +50,8 @@
     <Compile Include="Docking\DockPanel.DragHandler.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="Docking\DockToolStrip.cs" />
+    <Compile Include="Docking\DockUtils.cs" />
     <Compile Include="Docking\DragForm.cs">
       <SubType>Form</SubType>
     </Compile>


### PR DESCRIPTION
This pull implements a new DockArea flag to configure DockContents working similar as a Toolbar does. Activating this flag we can drag the windows in a specific toolbar-panel regardless of normal dock-panels.

The demo application contains a new button to test the behavior of this new toolbar-style DockArea flag.

![image](https://cloud.githubusercontent.com/assets/5576272/12699235/578a5e34-c7b4-11e5-8f9c-bf51998e47a8.png)
