### PR TITLE
AutoHideButton option, DockStateChanged event updates, AutoHidePortion work-around

### DIFF
--- a/WinFormsUI/Docking/DockContent.cs
+++ b/WinFormsUI/Docking/DockContent.cs
@@ -11,7 +11,7 @@ namespace WeifenLuo.WinFormsUI.Docking
         public DockContent()
         {
             m_dockHandler = new DockContentHandler(this, new GetPersistStringCallback(GetPersistString));
-            m_dockHandler.DockStateChanged += new EventHandler(DockHandler_DockStateChanged);
+            m_dockHandler.DockStateChanged += new EventHandler<DockStateChangedEventArgs>(DockHandler_DockStateChanged);
         }
 
         private DockContentHandler m_dockHandler = null;
@@ -302,7 +302,7 @@ namespace WeifenLuo.WinFormsUI.Docking
         #endregion
 
         #region Events
-        private void DockHandler_DockStateChanged(object sender, EventArgs e)
+        private void DockHandler_DockStateChanged(object sender, DockStateChangedEventArgs e)
         {
             OnDockStateChanged(e);
         }
@@ -310,14 +310,14 @@ namespace WeifenLuo.WinFormsUI.Docking
         private static readonly object DockStateChangedEvent = new object();
         [LocalizedCategory("Category_PropertyChanged")]
         [LocalizedDescription("Pane_DockStateChanged_Description")]
-        public event EventHandler DockStateChanged
+        public event EventHandler<DockStateChangedEventArgs> DockStateChanged
         {
             add { Events.AddHandler(DockStateChangedEvent, value); }
             remove { Events.RemoveHandler(DockStateChangedEvent, value); }
         }
-        protected virtual void OnDockStateChanged(EventArgs e)
+        protected virtual void OnDockStateChanged(DockStateChangedEventArgs e)
         {
-            EventHandler handler = (EventHandler)Events[DockStateChangedEvent];
+            EventHandler<DockStateChangedEventArgs> handler = (EventHandler<DockStateChangedEventArgs>)Events[DockStateChangedEvent];
             if (handler != null)
                 handler(this, e);
         }

--- a/WinFormsUI/Docking/DockContent.cs
+++ b/WinFormsUI/Docking/DockContent.cs
@@ -11,10 +11,7 @@ namespace WeifenLuo.WinFormsUI.Docking
         public DockContent()
         {
             m_dockHandler = new DockContentHandler(this, new GetPersistStringCallback(GetPersistString));
-            if (PatchController.EnableFontInheritanceFix != true)
-            {
-                m_dockHandler.DockStateChanged += new EventHandler(DockHandler_DockStateChanged);
-            }
+            m_dockHandler.DockStateChanged += new EventHandler(DockHandler_DockStateChanged);
         }
 
         private DockContentHandler m_dockHandler = null;

--- a/WinFormsUI/Docking/DockContent.cs
+++ b/WinFormsUI/Docking/DockContent.cs
@@ -85,6 +85,15 @@ namespace WeifenLuo.WinFormsUI.Docking
             set { DockHandler.CloseButtonVisible = value; }
         }
 
+        [LocalizedCategory("Category_Docking")]
+        [LocalizedDescription("DockContent_AutoHideButtonVisible_Description")]
+        [DefaultValue(true)]
+        public bool AutoHideButtonVisible
+        {
+            get { return DockHandler.AutoHideButtonVisible; }
+            set { DockHandler.AutoHideButtonVisible = value; }
+        }
+
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public DockPanel DockPanel

--- a/WinFormsUI/Docking/DockContentHandler.cs
+++ b/WinFormsUI/Docking/DockContentHandler.cs
@@ -642,7 +642,7 @@ namespace WeifenLuo.WinFormsUI.Docking
                 }
 
                 ResetAutoHidePortion(oldDockState, DockState);
-                OnDockStateChanged(EventArgs.Empty);
+                OnDockStateChanged(new DockStateChangedEventArgs(oldDockState, DockState));
             }
 
             ResumeSetDockState();
@@ -1049,14 +1049,14 @@ namespace WeifenLuo.WinFormsUI.Docking
 
         #region Events
         private static readonly object DockStateChangedEvent = new object();
-        public event EventHandler DockStateChanged
+        public event EventHandler<DockStateChangedEventArgs> DockStateChanged
         {
             add { Events.AddHandler(DockStateChangedEvent, value); }
             remove { Events.RemoveHandler(DockStateChangedEvent, value); }
         }
-        protected virtual void OnDockStateChanged(EventArgs e)
+        protected virtual void OnDockStateChanged(DockStateChangedEventArgs e)
         {
-            EventHandler handler = (EventHandler)Events[DockStateChangedEvent];
+            EventHandler<DockStateChangedEventArgs> handler = (EventHandler<DockStateChangedEventArgs>)Events[DockStateChangedEvent];
             if (handler != null)
                 handler(this, e);
         }

--- a/WinFormsUI/Docking/DockContentHandler.cs
+++ b/WinFormsUI/Docking/DockContentHandler.cs
@@ -68,6 +68,8 @@ namespace WeifenLuo.WinFormsUI.Docking
 
         public bool AllowEndUserDocking { get; set; } = true;
 
+        internal bool SuspendAutoHidePortionUpdates { get; set; } = false;
+
         private double m_autoHidePortion = 0.25;
         public double AutoHidePortion
         {
@@ -80,6 +82,9 @@ namespace WeifenLuo.WinFormsUI.Docking
             {
                 if (value <= 0)
                     throw (new ArgumentOutOfRangeException(Strings.DockContentHandler_AutoHidePortion_OutOfRange));
+
+                if (SuspendAutoHidePortionUpdates)
+                    return;
 
                 if (Math.Abs(m_autoHidePortion - value) < double.Epsilon)
                     return;

--- a/WinFormsUI/Docking/DockContentHandler.cs
+++ b/WinFormsUI/Docking/DockContentHandler.cs
@@ -135,6 +135,28 @@ namespace WeifenLuo.WinFormsUI.Docking
             }
         }
 
+        private bool m_autoHideButtonVisible = true;
+        /// <summary>
+        /// Determines whether the auto-hide (pin) button is visible when the content is docked as a tool.
+        /// </summary>
+        public bool AutoHideButtonVisible
+        {
+            get
+            {
+                return m_autoHideButtonVisible;
+            }
+            set
+            {
+                if (m_autoHideButtonVisible == value)
+                    return;
+
+                m_autoHideButtonVisible = value;
+                if (IsActiveContentHandler)
+                    Pane.RefreshChanges();
+            }
+        }
+
+
         private bool IsActiveContentHandler
         {
             get { return Pane != null && Pane.ActiveContent != null && Pane.ActiveContent.DockHandler == this; }

--- a/WinFormsUI/Docking/DockPanel.Persistor.cs
+++ b/WinFormsUI/Docking/DockPanel.Persistor.cs
@@ -701,7 +701,11 @@ namespace WeifenLuo.WinFormsUI.Docking
                 {
                     IDockContent content = dockPanel.Contents[sortedContents[i]];
                     if (content.DockHandler.Pane != null && content.DockHandler.Pane.DockState != DockState.Document)
+                    {
+                        content.DockHandler.SuspendAutoHidePortionUpdates = true;
                         content.DockHandler.IsHidden = contents[sortedContents[i]].IsHidden;
+                        content.DockHandler.SuspendAutoHidePortionUpdates = false;
+                    }
                 }
 
                 // after all non-document IDockContent, show document IDockContent
@@ -709,7 +713,11 @@ namespace WeifenLuo.WinFormsUI.Docking
                 {
                     IDockContent content = dockPanel.Contents[sortedContents[i]];
                     if (content.DockHandler.Pane != null && content.DockHandler.Pane.DockState == DockState.Document)
+                    {
+                        content.DockHandler.SuspendAutoHidePortionUpdates = true;
                         content.DockHandler.IsHidden = contents[sortedContents[i]].IsHidden;
+                        content.DockHandler.SuspendAutoHidePortionUpdates = false;
+                    }
                 }
 
                 for (int i = 0; i < panes.Length; i++)

--- a/WinFormsUI/Docking/DockPanel.Persistor.cs
+++ b/WinFormsUI/Docking/DockPanel.Persistor.cs
@@ -80,6 +80,13 @@ namespace WeifenLuo.WinFormsUI.Docking
                     set { m_autoHidePortion = value; }
                 }
 
+                private bool m_autoHideButtonVisible;
+                public bool AutoHideButtonVisible
+                {
+                    get { return m_autoHideButtonVisible; }
+                    set { m_autoHideButtonVisible = value; }
+                }
+
                 private bool m_isHidden;
                 public bool IsHidden
                 {
@@ -265,6 +272,7 @@ namespace WeifenLuo.WinFormsUI.Docking
                     xmlOut.WriteAttributeString("ID", dockPanel.Contents.IndexOf(content).ToString(CultureInfo.InvariantCulture));
                     xmlOut.WriteAttributeString("PersistString", content.DockHandler.PersistString);
                     xmlOut.WriteAttributeString("AutoHidePortion", content.DockHandler.AutoHidePortion.ToString(CultureInfo.InvariantCulture));
+                    xmlOut.WriteAttributeString("AutoHideButtonVisible", content.DockHandler.AutoHideButtonVisible.ToString(CultureInfo.InvariantCulture));
                     xmlOut.WriteAttributeString("IsHidden", content.DockHandler.IsHidden.ToString(CultureInfo.InvariantCulture));
                     xmlOut.WriteAttributeString("IsFloat", content.DockHandler.IsFloat.ToString(CultureInfo.InvariantCulture));
                     xmlOut.WriteEndElement();
@@ -389,6 +397,7 @@ namespace WeifenLuo.WinFormsUI.Docking
 
                     contents[i].PersistString = xmlIn.GetAttribute("PersistString");
                     contents[i].AutoHidePortion = Convert.ToDouble(xmlIn.GetAttribute("AutoHidePortion"), CultureInfo.InvariantCulture);
+                    contents[i].AutoHideButtonVisible = Convert.ToBoolean(xmlIn.GetAttribute("AutoHideButtonVisible"), CultureInfo.InvariantCulture);
                     contents[i].IsHidden = Convert.ToBoolean(xmlIn.GetAttribute("IsHidden"), CultureInfo.InvariantCulture);
                     contents[i].IsFloat = Convert.ToBoolean(xmlIn.GetAttribute("IsFloat"), CultureInfo.InvariantCulture);
                     MoveToNextElement(xmlIn);

--- a/WinFormsUI/Docking/DockStateChangedEventArgs.cs
+++ b/WinFormsUI/Docking/DockStateChangedEventArgs.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace WeifenLuo.WinFormsUI.Docking
+{
+    public class DockStateChangedEventArgs : EventArgs
+    {
+        public DockState OldState { get; private set; }
+
+        public DockState NewState { get; private set; }
+
+        public DockStateChangedEventArgs(DockState oldState, DockState newState)
+        {
+            OldState = oldState;
+            NewState = newState;
+        }
+    }
+}

--- a/WinFormsUI/Docking/Strings.Designer.cs
+++ b/WinFormsUI/Docking/Strings.Designer.cs
@@ -115,6 +115,15 @@ namespace WeifenLuo.WinFormsUI.Docking {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Shows or hides the auto-hide (pin) button of the content, when docked as a tool..
+        /// </summary>
+        internal static string DockContent_AutoHideButtonVisible_Description {
+            get {
+                return ResourceManager.GetString("DockContent_AutoHideButtonVisible_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The size to display the content in auto hide mode. Value &lt; 1 to specify the size in portion; value &gt;= 1 to specify the size in pixel..
         /// </summary>
         internal static string DockContent_AutoHidePortion_Description {

--- a/WinFormsUI/Docking/Strings.resx
+++ b/WinFormsUI/Docking/Strings.resx
@@ -258,10 +258,10 @@
   <data name="DockPanel_ActiveContentChanged_Description" xml:space="preserve">
     <value>Occurs when the value of ActiveContentProperty changed.</value>
   </data>
-	<data name="DockPanel_DocumentDragged_Description" xml:space="preserve">
+  <data name="DockPanel_DocumentDragged_Description" xml:space="preserve">
     <value>Occurs when a document or pane is dragged within the dock panel.</value>
   </data>
-	<data name="DockPanel_ActiveDocumentChanged_Description" xml:space="preserve">
+  <data name="DockPanel_ActiveDocumentChanged_Description" xml:space="preserve">
     <value>Occurs when the value of ActiveDocument property changed.</value>
   </data>
   <data name="DockPanel_ActivePaneChanged_Description" xml:space="preserve">
@@ -371,5 +371,8 @@
   </data>
   <data name="DockPanel_ShowAutoHideContentOnHover_Description" xml:space="preserve">
     <value>Shows the hidden autohide content when hovering over the tab.  When disabled, the tab must be clicked to show the content.</value>
+  </data>
+  <data name="DockContent_AutoHideButtonVisible_Description" xml:space="preserve">
+    <value>Shows or hides the auto-hide (pin) button of the content, when docked as a tool.</value>
   </data>
 </root>

--- a/WinFormsUI/Docking/VS2005DockPaneCaption.cs
+++ b/WinFormsUI/Docking/VS2005DockPaneCaption.cs
@@ -416,7 +416,7 @@ namespace WeifenLuo.WinFormsUI.Docking
 
         private bool ShouldShowAutoHideButton
         {
-            get	{	return !DockPane.IsFloat;	}
+            get	{	return !DockPane.IsFloat && ((DockPane.ActiveContent != null) ? DockPane.ActiveContent.DockHandler.AutoHideButtonVisible : true);	}
         }
 
         private void SetButtons()

--- a/WinFormsUI/ThemeVS2005Multithreading/VS2005MultithreadingDockPaneCaption.cs
+++ b/WinFormsUI/ThemeVS2005Multithreading/VS2005MultithreadingDockPaneCaption.cs
@@ -379,7 +379,7 @@ namespace WeifenLuo.WinFormsUI.Docking
 
         private bool ShouldShowAutoHideButton
         {
-            get	{	return !DockPane.IsFloat;	}
+            get	{	return !DockPane.IsFloat && ((DockPane.ActiveContent != null) ? DockPane.ActiveContent.DockHandler.AutoHideButtonVisible : true);	}
         }
 
         private void SetButtons()

--- a/WinFormsUI/ThemeVS2010/VS2010DockPaneCaption.cs
+++ b/WinFormsUI/ThemeVS2010/VS2010DockPaneCaption.cs
@@ -292,7 +292,7 @@ namespace WeifenLuo.WinFormsUI.ThemeVS2010
 
         private bool ShouldShowAutoHideButton
         {
-            get	{	return !DockPane.IsFloat;	}
+            get	{	return !DockPane.IsFloat && ((DockPane.ActiveContent != null) ? DockPane.ActiveContent.DockHandler.AutoHideButtonVisible : true);	}
         }
 
         private void SetButtons()

--- a/WinFormsUI/ThemeVS2012/VS2012DockPaneCaption.cs
+++ b/WinFormsUI/ThemeVS2012/VS2012DockPaneCaption.cs
@@ -291,7 +291,7 @@ namespace WeifenLuo.WinFormsUI.Docking
 
         private bool ShouldShowAutoHideButton
         {
-            get	{	return !DockPane.IsFloat;	}
+            get	{	return !DockPane.IsFloat && ((DockPane.ActiveContent != null) ? DockPane.ActiveContent.DockHandler.AutoHideButtonVisible : true);	}
         }
 
         private void SetButtons()

--- a/WinFormsUI/ThemeVS2013/VS2013DockPaneCaption.cs
+++ b/WinFormsUI/ThemeVS2013/VS2013DockPaneCaption.cs
@@ -290,7 +290,7 @@ namespace WeifenLuo.WinFormsUI.Docking
 
         private bool ShouldShowAutoHideButton
         {
-            get	{	return !DockPane.IsFloat;	}
+            get	{	return !DockPane.IsFloat && ((DockPane.ActiveContent != null) ? DockPane.ActiveContent.DockHandler.AutoHideButtonVisible : true);	}
         }
 
         private void SetButtons()

--- a/WinFormsUI/WinFormsUI.csproj
+++ b/WinFormsUI/WinFormsUI.csproj
@@ -55,6 +55,7 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="Docking\DockPanelColorPalette.cs" />
+    <Compile Include="Docking\DockStateChangedEventArgs.cs" />
     <Compile Include="Docking\DragForm.cs">
       <SubType>Form</SubType>
     </Compile>


### PR DESCRIPTION
The original VS2003 theme is unchanged, but VS2005, VS2010, VS2012, VS2013 (and therefore VS2015) handle this option.
Included code to save to xml/load from xml.

Always have DockContent listen to DockHandler.DockStateChanged event

Added DockStateChangedEventArgs to DockStateChanged event, giving OldState and NewState.

Added work-around for AutoHidePortion being reset (Issue #414)