### PR TITLE
Fix for pane resize in Mono (Issue #430)

### DIFF
--- a/WinFormsUI/Docking/DockPanel.DragHandler.cs
+++ b/WinFormsUI/Docking/DockPanel.DragHandler.cs
@@ -76,7 +76,7 @@ namespace WeifenLuo.WinFormsUI.Docking
                 else if (m.Msg == (int)Win32.Msgs.WM_LBUTTONUP)
                     EndDrag(false);
                 else if (m.Msg == (int)Win32.Msgs.WM_CAPTURECHANGED)
-                    EndDrag(true);
+                    EndDrag(!Win32Helper.IsRunningOnMono);
                 else if (m.Msg == (int)Win32.Msgs.WM_KEYDOWN && (int)m.WParam == (int)Keys.Escape)
                     EndDrag(true);
 

--- a/WinFormsUI/Docking/DockPanel.SplitterDragHandler.cs
+++ b/WinFormsUI/Docking/DockPanel.SplitterDragHandler.cs
@@ -36,6 +36,7 @@ namespace WeifenLuo.WinFormsUI.Docking
 
                 public void Close()
                 {
+                    DragForm.Bounds = Rectangle.Empty;
                     DragForm.Close();
                 }
 


### PR DESCRIPTION
* Will now actually resize panes in Mono (action was interpreted as "canceled" in Mono due to a missing mouse message)
* Resize bar will no longer linger