### PR TITLE
Work-around for themed ToolStrip in mono Mono (Issue #432)

### DIFF
--- a/WinFormsUI/Docking/ThemeBase.cs
+++ b/WinFormsUI/Docking/ThemeBase.cs
@@ -38,7 +38,7 @@ namespace WeifenLuo.WinFormsUI.Docking
             _stripBefore.Add(toolStrip, new KeyValuePair<ToolStripRenderMode, ToolStripRenderer>(toolStrip.RenderMode, toolStrip.Renderer));
             toolStrip.Renderer = ToolStripRenderer;
 
-            if(Win32Helper.IsRunningOnMono)
+            if (Win32Helper.IsRunningOnMono)
             {
                 foreach (var item in toolStrip.Items.OfType<ToolStripDropDownItem>())
                 {

--- a/WinFormsUI/Docking/ThemeBase.cs
+++ b/WinFormsUI/Docking/ThemeBase.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
+using System.Linq;
 using System.Windows.Forms;
 
 namespace WeifenLuo.WinFormsUI.Docking
@@ -36,6 +37,26 @@ namespace WeifenLuo.WinFormsUI.Docking
 
             _stripBefore.Add(toolStrip, new KeyValuePair<ToolStripRenderMode, ToolStripRenderer>(toolStrip.RenderMode, toolStrip.Renderer));
             toolStrip.Renderer = ToolStripRenderer;
+
+            if(Win32Helper.IsRunningOnMono)
+            {
+                foreach (var item in toolStrip.Items.OfType<ToolStripDropDownItem>())
+                {
+                    ItemResetOwnerHack(item);
+                }
+            }
+        }
+
+        private void ItemResetOwnerHack(ToolStripDropDownItem item)
+        {
+            var oldOwner = item.DropDown.OwnerItem;
+            item.DropDown.OwnerItem = null;
+            item.DropDown.OwnerItem = oldOwner;
+
+            foreach (var child in item.DropDownItems.OfType<ToolStripDropDownItem>())
+            {
+                ItemResetOwnerHack(child);
+            }
         }
 
         private KeyValuePair<ToolStripManagerRenderMode, ToolStripRenderer> _managerBefore;


### PR DESCRIPTION
The hack is to remove and re-apply "OwnerItem" property (recursively) after setting the Renderer on a ToolStrip
