### PR TITLE
Apply theme to menus of DockContents (Issue #433)

### DIFF
--- a/WinFormsUI/Docking/DockContent.cs
+++ b/WinFormsUI/Docking/DockContent.cs
@@ -219,7 +219,7 @@ namespace WeifenLuo.WinFormsUI.Docking
             {
                 if (MainMenuStrip != null)
                     DockPanel.Theme.ApplyTo(MainMenuStrip);
-                if(ContextMenuStrip != null)
+                if (ContextMenuStrip != null)
                     DockPanel.Theme.ApplyTo(ContextMenuStrip);
             }
         }

--- a/WinFormsUI/Docking/DockContent.cs
+++ b/WinFormsUI/Docking/DockContent.cs
@@ -214,6 +214,14 @@ namespace WeifenLuo.WinFormsUI.Docking
         public void ApplyTheme()
         {
             DockHandler.ApplyTheme();
+
+            if (DockPanel != null)
+            {
+                if (MainMenuStrip != null)
+                    DockPanel.Theme.ApplyTo(MainMenuStrip);
+                if(ContextMenuStrip != null)
+                    DockPanel.Theme.ApplyTo(ContextMenuStrip);
+            }
         }
 
         [Localizable(true)]


### PR DESCRIPTION
Themes should apply to menus (MainMenuStrip and ContextMenuStrip) of DockContents.

It would be possible to recursive loop through all it's Controls, but I this is at least a start.
