### PR TITLE
Fix for VS2015 menu strip, not drawing "glass"

### DIFF
--- a/WinFormsUI/Docking/VisualStudioToolStripRenderer.cs
+++ b/WinFormsUI/Docking/VisualStudioToolStripRenderer.cs
@@ -31,6 +31,8 @@ namespace WeifenLuo.WinFormsUI.Docking
         private VisualStudioColorTable _table;
         private DockPanelColorPalette _palette;
 
+        public bool UseGlassOnMenuStrip { get; set; }
+
         public VisualStudioToolStripRenderer(DockPanelColorPalette palette)
             : base(new VisualStudioColorTable(palette))
         {
@@ -43,6 +45,8 @@ namespace WeifenLuo.WinFormsUI.Docking
             _toolBarBrush = new SolidBrush(palette.CommandBarToolbarDefault.Background);
             _gripBrush = new SolidBrush(palette.CommandBarToolbarDefault.Grip);
             _toolBarBorderPen = new Pen(palette.CommandBarToolbarDefault.Border);
+
+            UseGlassOnMenuStrip = true;
         }
 
         #region Rendering Improvements (includes fixes for bugs occured when Windows Classic theme is on).
@@ -87,7 +91,7 @@ namespace WeifenLuo.WinFormsUI.Docking
                         brushEnd = Color.Empty;
                     }
 
-                    DrawRectangle(e.Graphics, itemRect, brushBegin, brushEnd, pen, true);
+                    DrawRectangle(e.Graphics, itemRect, brushBegin, brushEnd, pen, UseGlassOnMenuStrip);
                 }
             }
         }

--- a/WinFormsUI/ThemeVS2015/VS2015ThemeBase.cs
+++ b/WinFormsUI/ThemeVS2015/VS2015ThemeBase.cs
@@ -15,7 +15,10 @@ namespace WeifenLuo.WinFormsUI.ThemeVS2015
             Skin = new DockPanelSkin();
             PaintingService = new PaintingService();
             ImageService = new ImageService(this);
-            ToolStripRenderer = new VisualStudioToolStripRenderer(ColorPalette);
+            ToolStripRenderer = new VisualStudioToolStripRenderer(ColorPalette)
+            {
+                UseGlassOnMenuStrip = false,
+            };
             Measures.SplitterSize = 6;
             Measures.AutoHideSplitterSize = 3;
             Measures.DockPadding = 6;


### PR DESCRIPTION
VS2013 theme had a "glass" being drawn, which made the menus look double-colored. VS2015 does not have this, so the theme shouldn't either. Made it optional, with default ON for VS2013 and default OFF for VS2015.

Could possibley make it something that could be toggled on the theme itself, but at least it is corrected now.