### PR TITLE
Workaround-workaround for Mono (Issue #441)

### DIFF
--- a/WinFormsUI/Docking/DockContentHandler.cs
+++ b/WinFormsUI/Docking/DockContentHandler.cs
@@ -877,7 +877,7 @@ namespace WeifenLuo.WinFormsUI.Docking
             // Change the parent of a control with focus may result in the first
             // MDI child form get activated. 
             // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-            if (bRestoreFocus)
+            if (bRestoreFocus && !Win32Helper.IsRunningOnMono)
                 Activate();
 
             // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!


### PR DESCRIPTION
When loading from xml, if having more than one pane (like top+bottom or more), the load crashes on Mono and leaves the DockPanel completely empty.
