### PR TITLE
Sample: fix crash when set same theme

### DIFF
--- a/WinFormsUI/Docking/ThemeBase.cs
+++ b/WinFormsUI/Docking/ThemeBase.cs
@@ -35,7 +35,7 @@ namespace WeifenLuo.WinFormsUI.Docking
             if (toolStrip == null)
                 return;
 
-            _stripBefore.Add(toolStrip, new KeyValuePair<ToolStripRenderMode, ToolStripRenderer>(toolStrip.RenderMode, toolStrip.Renderer));
+            _stripBefore[toolStrip] = new KeyValuePair<ToolStripRenderMode, ToolStripRenderer>(toolStrip.RenderMode, toolStrip.Renderer);
             toolStrip.Renderer = ToolStripRenderer;
 
             if (Win32Helper.IsRunningOnMono)


### PR DESCRIPTION
In sample project if I set already checked theme in menu program will
crash. Crash happens because toolstrip key already exists in some
dictionary. This fix simple changes Add method to indexer method, so
toolstrip will be replaced.