### PR TITLE
Added missing tooltips to the document tabs in the VS2010, VS2012 and VS2013 themes

### DIFF
--- a/WinFormsUI/ThemeVS2010/VS2010DockPaneStrip.cs
+++ b/WinFormsUI/ThemeVS2010/VS2010DockPaneStrip.cs
@@ -121,6 +121,7 @@ namespace WeifenLuo.WinFormsUI.ThemeVS2010
         private InertButton m_buttonOverflow;
         private InertButton m_buttonWindowList;
         private IContainer m_components;
+        private ToolTip m_toolTip;
         private Font m_font;
         private Font m_boldFont;
         private int m_startDisplayingTab = 0;
@@ -510,6 +511,7 @@ namespace WeifenLuo.WinFormsUI.ThemeVS2010
             SuspendLayout();
 
             m_components = new Container();
+            m_toolTip = new ToolTip(Components);
             m_selectMenu = new ContextMenuStrip(Components);
             pane.DockPanel.Theme.ApplyTo(m_selectMenu);
 
@@ -1253,6 +1255,13 @@ namespace WeifenLuo.WinFormsUI.ThemeVS2010
 
             if (tabUpdate || buttonUpdate)
                 Invalidate();
+
+            if (m_toolTip.GetToolTip(this) != toolTip)
+            {
+                m_toolTip.Active = false;
+                m_toolTip.SetToolTip(this, toolTip);
+                m_toolTip.Active = true;
+            }
         }
 
         protected override void OnMouseClick(MouseEventArgs e)

--- a/WinFormsUI/ThemeVS2012/VS2012DockPaneStrip.cs
+++ b/WinFormsUI/ThemeVS2012/VS2012DockPaneStrip.cs
@@ -120,6 +120,7 @@ namespace WeifenLuo.WinFormsUI.Docking
         private InertButton m_buttonOverflow;
         private InertButton m_buttonWindowList;
         private IContainer m_components;
+        private ToolTip m_toolTip;
         private Font m_font;
         private Font m_boldFont;
         private int m_startDisplayingTab = 0;
@@ -509,6 +510,7 @@ namespace WeifenLuo.WinFormsUI.Docking
             SuspendLayout();
 
             m_components = new Container();
+            m_toolTip = new ToolTip(Components);
             m_selectMenu = new ContextMenuStrip(Components);
             pane.DockPanel.Theme.ApplyTo(m_selectMenu);
 
@@ -1252,6 +1254,13 @@ namespace WeifenLuo.WinFormsUI.Docking
 
             if (tabUpdate || buttonUpdate)
                 Invalidate();
+
+            if (m_toolTip.GetToolTip(this) != toolTip)
+            {
+                m_toolTip.Active = false;
+                m_toolTip.SetToolTip(this, toolTip);
+                m_toolTip.Active = true;
+            }
         }
 
         protected override void OnMouseClick(MouseEventArgs e)

--- a/WinFormsUI/ThemeVS2013/VS2013DockPaneStrip.cs
+++ b/WinFormsUI/ThemeVS2013/VS2013DockPaneStrip.cs
@@ -120,6 +120,7 @@ namespace WeifenLuo.WinFormsUI.ThemeVS2013
         private InertButton m_buttonOverflow;
         private InertButton m_buttonWindowList;
         private IContainer m_components;
+        private ToolTip m_toolTip;
         private Font m_font;
         private Font m_boldFont;
         private int m_startDisplayingTab = 0;
@@ -509,6 +510,7 @@ namespace WeifenLuo.WinFormsUI.ThemeVS2013
             SuspendLayout();
 
             m_components = new Container();
+            m_toolTip = new ToolTip(Components);
             m_selectMenu = new ContextMenuStrip(Components);
             pane.DockPanel.Theme.ApplyTo(m_selectMenu);
 
@@ -1260,6 +1262,13 @@ namespace WeifenLuo.WinFormsUI.ThemeVS2013
 
             if (tabUpdate || buttonUpdate)
                 Invalidate();
+
+            if (m_toolTip.GetToolTip(this) != toolTip)
+            {
+                m_toolTip.Active = false;
+                m_toolTip.SetToolTip(this, toolTip);
+                m_toolTip.Active = true;
+            }
         }
 
         protected override void OnMouseClick(MouseEventArgs e)


### PR DESCRIPTION
After the https://github.com/dockpanelsuite/dockpanelsuite/commit/519b917f2816d312bbb1f143351c20bfffc2009c commit document tab tooltips are not being shown when the VS2010, VS2012 or VS2013 theme is set. This pull restores missing tooltips in these themes.