### PR TITLE
Uninstall Hook if last Focus Manager is disposed

### DIFF
--- a/WinFormsUI/Docking/DockPanel.FocusManager.cs
+++ b/WinFormsUI/Docking/DockPanel.FocusManager.cs
@@ -120,6 +120,7 @@ namespace WeifenLuo.WinFormsUI.Docking
             // Use a static instance of the windows hook to prevent stack overflows in the windows kernel.
             [ThreadStatic]
             private static LocalWindowsHook sm_localWindowsHook;
+            [ThreadStatic]
             private static int _referenceCount = 0;
 
             private readonly LocalWindowsHook.HookEventHandler m_hookEventHandler;
@@ -161,8 +162,11 @@ namespace WeifenLuo.WinFormsUI.Docking
                     --_referenceCount;
 
                     if (_referenceCount == 0)
+                    {
                         sm_localWindowsHook.Dispose();
-                    
+                        sm_localWindowsHook = null;
+                    }
+					
                     m_disposed = true;
                 }
 

--- a/WinFormsUI/Docking/DockPanel.FocusManager.cs
+++ b/WinFormsUI/Docking/DockPanel.FocusManager.cs
@@ -161,7 +161,7 @@ namespace WeifenLuo.WinFormsUI.Docking
 
                     --_referenceCount;
 
-                    if (_referenceCount == 0)
+                    if (_referenceCount == 0 && sm_localWindowsHook != null)
                     {
                         sm_localWindowsHook.Dispose();
                         sm_localWindowsHook = null;

--- a/WinFormsUI/Docking/DockPanel.FocusManager.cs
+++ b/WinFormsUI/Docking/DockPanel.FocusManager.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
@@ -158,7 +157,10 @@ namespace WeifenLuo.WinFormsUI.Docking
                     {
                         sm_localWindowsHook.HookInvoked -= m_hookEventHandler;
                     }
-                    if (--_referenceCount == 0)
+
+                    --_referenceCount;
+
+                    if (_referenceCount == 0)
                         sm_localWindowsHook.Dispose();
                     
                     m_disposed = true;

--- a/WinFormsUI/Docking/DockPanel.FocusManager.cs
+++ b/WinFormsUI/Docking/DockPanel.FocusManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
@@ -120,6 +121,7 @@ namespace WeifenLuo.WinFormsUI.Docking
             // Use a static instance of the windows hook to prevent stack overflows in the windows kernel.
             [ThreadStatic]
             private static LocalWindowsHook sm_localWindowsHook;
+            private static int _referenceCount = 0;
 
             private readonly LocalWindowsHook.HookEventHandler m_hookEventHandler;
 
@@ -138,6 +140,7 @@ namespace WeifenLuo.WinFormsUI.Docking
                 }
 
                 sm_localWindowsHook.HookInvoked += m_hookEventHandler;
+                ++_referenceCount;
             }
 
             private DockPanel m_dockPanel;
@@ -155,7 +158,9 @@ namespace WeifenLuo.WinFormsUI.Docking
                     {
                         sm_localWindowsHook.HookInvoked -= m_hookEventHandler;
                     }
-
+                    if (--_referenceCount == 0)
+                        sm_localWindowsHook.Dispose();
+                    
                     m_disposed = true;
                 }
 


### PR DESCRIPTION
not uninstalling it leads to win32 exception when closing application.

This commit should fix https://github.com/dockpanelsuite/dockpanelsuite/issues/157 on Windows 10.