### PR TITLE
Add IsActivatedChanged event for DockContent and DockContentHandler

### DIFF
--- a/WinFormsUI/Docking/DockContent.cs
+++ b/WinFormsUI/Docking/DockContent.cs
@@ -12,6 +12,7 @@ namespace WeifenLuo.WinFormsUI.Docking
         {
             m_dockHandler = new DockContentHandler(this, new GetPersistStringCallback(GetPersistString));
             m_dockHandler.DockStateChanged += new EventHandler(DockHandler_DockStateChanged);
+            m_dockHandler.IsActivatedChanged += new EventHandler(DockHandler_IsActivatedChanged);
             if (PatchController.EnableFontInheritanceFix != true)
             {
                 //Suggested as a fix by bensty regarding form resize
@@ -329,6 +330,24 @@ namespace WeifenLuo.WinFormsUI.Docking
         protected virtual void OnDockStateChanged(EventArgs e)
         {
             EventHandler handler = (EventHandler)Events[DockStateChangedEvent];
+            if (handler != null)
+                handler(this, e);
+        }
+
+        private void DockHandler_IsActivatedChanged(object sender, EventArgs e)
+        {
+            OnIsActivatedChanged(e);
+        }
+
+        private static readonly object IsActivatedChangedEvent = new object();
+        public event EventHandler IsActivatedChanged
+        {
+            add { Events.AddHandler(IsActivatedChangedEvent, value); }
+            remove { Events.RemoveHandler(IsActivatedChangedEvent, value); }
+        }
+        protected virtual void OnIsActivatedChanged(EventArgs e)
+        {
+            EventHandler handler = (EventHandler) Events[IsActivatedChangedEvent];
             if (handler != null)
                 handler(this, e);
         }

--- a/WinFormsUI/Docking/DockContentHandler.cs
+++ b/WinFormsUI/Docking/DockContentHandler.cs
@@ -702,14 +702,14 @@ namespace WeifenLuo.WinFormsUI.Docking
             {
                 return m_isActivated;
             }
+        }
+        internal void SetIsActivated(bool value)
+        {
+            if (m_isActivated == value)
+                return;
 
-            internal set
-            {
-                if (m_isActivated == value)
-                    return;
-
-                m_isActivated = value;
-            }
+            m_isActivated = value;
+            OnIsActivatedChanged(EventArgs.Empty);
         }
 
         public bool IsDockStateValid(DockState dockState)
@@ -1040,6 +1040,19 @@ namespace WeifenLuo.WinFormsUI.Docking
         protected virtual void OnDockStateChanged(EventArgs e)
         {
             EventHandler handler = (EventHandler)Events[DockStateChangedEvent];
+            if (handler != null)
+                handler(this, e);
+        }
+
+        private static readonly object IsActivatedChangedEvent = new object();
+        public event EventHandler IsActivatedChanged
+        {
+            add { Events.AddHandler(IsActivatedChangedEvent, value); }
+            remove { Events.RemoveHandler(IsActivatedChangedEvent, value); }
+        }
+        protected virtual void OnIsActivatedChanged(EventArgs e)
+        {
+            EventHandler handler = (EventHandler) Events[IsActivatedChangedEvent];
             if (handler != null)
                 handler(this, e);
         }

--- a/WinFormsUI/Docking/DockPanel.FocusManager.cs
+++ b/WinFormsUI/Docking/DockPanel.FocusManager.cs
@@ -459,13 +459,13 @@ namespace WeifenLuo.WinFormsUI.Docking
                     return;
 
                 if (m_activeContent != null)
-                    m_activeContent.DockHandler.IsActivated = false;
+                    m_activeContent.DockHandler.SetIsActivated(false);
 
                 m_activeContent = value;
 
                 if (m_activeContent != null)
                 {
-                    m_activeContent.DockHandler.IsActivated = true;
+                    m_activeContent.DockHandler.SetIsActivated(true);
                     if (!DockHelper.IsDockStateAutoHide((m_activeContent.DockHandler.DockState)))
                         AddLastToActiveList(m_activeContent);
                 }


### PR DESCRIPTION
Sometimes the code structure required me to listen to the modification of `IsActivated` of `DockContent` instead of `ActiveContentChanged`, but there currently isn't any way to do so.