### PR TITLE
HitTestCaption in Mono

### DIFF
--- a/WinFormsUI/Docking/FloatWindow.cs
+++ b/WinFormsUI/Docking/FloatWindow.cs
@@ -207,7 +207,7 @@ namespace WeifenLuo.WinFormsUI.Docking
                     }
                 case (int)Win32.Msgs.WM_NCRBUTTONDOWN:
                     {
-                        uint result = Win32Helper.IsRunningOnMono ? 0 : NativeMethods.SendMessage(this.Handle, (int)Win32.Msgs.WM_NCHITTEST, 0, (uint)m.LParam);
+                        uint result = Win32Helper.IsRunningOnMono ? Win32Helper.HitTestCaption(this) : NativeMethods.SendMessage(this.Handle, (int)Win32.Msgs.WM_NCHITTEST, 0, (uint)m.LParam);
                         if (result == 2)	// HITTEST_CAPTION
                         {
                             DockPane theOnlyPane = (VisibleNestedPanes.Count == 1) ? VisibleNestedPanes[0] : null;
@@ -249,7 +249,7 @@ namespace WeifenLuo.WinFormsUI.Docking
                 case (int)Win32.Msgs.WM_NCLBUTTONDBLCLK:
                     {
                         uint result = !DoubleClickTitleBarToDock || Win32Helper.IsRunningOnMono 
-                            ? 0
+                            ? Win32Helper.HitTestCaption(this)
                             : NativeMethods.SendMessage(this.Handle, (int)Win32.Msgs.WM_NCHITTEST, 0, (uint)m.LParam);
 
                         if (result != 2)	// HITTEST_CAPTION

--- a/WinFormsUI/Docking/Helpers/Win32Helper.cs
+++ b/WinFormsUI/Docking/Helpers/Win32Helper.cs
@@ -19,5 +19,11 @@ namespace WeifenLuo.WinFormsUI.Docking
         {
             return (uint)((high << 16) + low);
         }
+
+        internal static uint HitTestCaption(Control control)
+        {
+            var captionRectangle = new Rectangle(0, 0, control.Width, control.ClientRectangle.Top - control.PointToClient(control.Location).X);
+            return captionRectangle.Contains(Control.MousePosition) ? (uint)2 : 0;
+        }
     }
 }


### PR DESCRIPTION
Implemented HitTestCaption method for Control in Mono, allowing context menus (and caption double-click) to work (issue #492).