### PR TITLE
default text color to theme

### DIFF
--- a/WinFormsUI/Docking/VisualStudioToolStripRenderer.cs
+++ b/WinFormsUI/Docking/VisualStudioToolStripRenderer.cs
@@ -410,6 +410,18 @@ namespace WeifenLuo.WinFormsUI.Docking
                     color = _palette.CommandBarMenuDefault.Text;
                 }
             }
+            else 
+            {
+                // Default color, if not it will be black no matter what 
+                if (!e.Item.Enabled)
+                {
+                    color = _palette.CommandBarMenuPopupDisabled.Text;
+                } 
+                else
+                {
+                    color = _palette.CommandBarMenuDefault.Text;
+                }
+            }
 
             TextRenderer.DrawText(e.Graphics, e.Text, e.TextFont, e.TextRectangle, color, e.TextFormat);
         }


### PR DESCRIPTION
default text color to theme, if not it will be always black (dark themes conflict for some items that are not in the if-else scheme).