### PR TITLE
Add BeforeEndDrag and EndDrag event

### DIFF
--- a/WinFormsUI/Docking/DockContent.cs
+++ b/WinFormsUI/Docking/DockContent.cs
@@ -12,6 +12,8 @@ namespace WeifenLuo.WinFormsUI.Docking
         {
             m_dockHandler = new DockContentHandler(this, new GetPersistStringCallback(GetPersistString));
             m_dockHandler.DockStateChanged += new EventHandler(DockHandler_DockStateChanged);
+            m_dockHandler.BeforeEndDrag += new EventHandler(DockHandler_BeforeEndDrag);
+            m_dockHandler.EndDrag += new EventHandler(DockHandler_EndDrag);
             if (PatchController.EnableFontInheritanceFix != true)
             {
                 //Suggested as a fix by bensty regarding form resize
@@ -329,6 +331,42 @@ namespace WeifenLuo.WinFormsUI.Docking
         protected virtual void OnDockStateChanged(EventArgs e)
         {
             ((EventHandler)Events[DockStateChangedEvent])?.Invoke(this, e);
+        }
+
+        private void DockHandler_BeforeEndDrag(object sender, EventArgs e)
+        {
+            OnBeforeEndDrag(e);
+        }
+
+        private static readonly object BeforeEndDragEvent = new object();
+        public event EventHandler BeforeEndDrag
+        {
+            add { Events.AddHandler(BeforeEndDragEvent, value); }
+            remove { Events.RemoveHandler(BeforeEndDragEvent, value); }
+        }
+        protected virtual void OnBeforeEndDrag(EventArgs e)
+        {
+            EventHandler handler = (EventHandler)Events[BeforeEndDragEvent];
+            if (handler != null)
+                handler(this, e);
+        }
+
+        private void DockHandler_EndDrag(object sender, EventArgs e)
+        {
+            OnEndDrag(e);
+        }
+
+        private static readonly object EndDragEvent = new object();
+        public event EventHandler EndDrag
+        {
+            add { Events.AddHandler(EndDragEvent, value); }
+            remove { Events.RemoveHandler(EndDragEvent, value); }
+        }
+        protected virtual void OnEndDrag(EventArgs e)
+        {
+            EventHandler handler = (EventHandler)Events[EndDragEvent];
+            if (handler != null)
+                handler(this, e);
         }
         #endregion
 

--- a/WinFormsUI/Docking/DockContentHandler.cs
+++ b/WinFormsUI/Docking/DockContentHandler.cs
@@ -1164,8 +1164,30 @@ namespace WeifenLuo.WinFormsUI.Docking
             return new Rectangle(location, size);
         }
 
+        private static readonly object BeforeEndDragEvent = new object();
+        public event EventHandler BeforeEndDrag
+        {
+            add { Events.AddHandler(BeforeEndDragEvent, value); }
+            remove { Events.RemoveHandler(BeforeEndDragEvent, value); }
+        }
+        void IDockDragSource.BeforeEndDrag()
+        {
+            EventHandler handler = (EventHandler)Events[BeforeEndDragEvent];
+            if (handler != null)
+                handler(this, EventArgs.Empty);
+        }
+
+        private static readonly object EndDragEvent = new object();
+        public event EventHandler EndDrag
+        {
+            add { Events.AddHandler(EndDragEvent, value); }
+            remove { Events.RemoveHandler(EndDragEvent, value); }
+        }
         void IDockDragSource.EndDrag()
         {
+            EventHandler handler = (EventHandler)Events[EndDragEvent];
+            if (handler != null)
+                handler(this, EventArgs.Empty);
         }
 
         public void FloatAt(Rectangle floatWindowBounds)

--- a/WinFormsUI/Docking/DockPane.cs
+++ b/WinFormsUI/Docking/DockPane.cs
@@ -1272,6 +1272,10 @@ namespace WeifenLuo.WinFormsUI.Docking
             return new Rectangle(location, size);
         }
 
+        void IDockDragSource.BeforeEndDrag()
+        {
+        }
+
         void IDockDragSource.EndDrag()
         {
         }

--- a/WinFormsUI/Docking/DockPanel.DockDragHandler.cs
+++ b/WinFormsUI/Docking/DockPanel.DockDragHandler.cs
@@ -756,6 +756,8 @@ namespace WeifenLuo.WinFormsUI.Docking
                 Outline.Close();
                 Indicator.Close();
 
+                DragSource.BeforeEndDrag();
+
                 EndDrag(abort);
 
                 // Queue a request to layout all children controls

--- a/WinFormsUI/Docking/FloatWindow.cs
+++ b/WinFormsUI/Docking/FloatWindow.cs
@@ -377,6 +377,10 @@ namespace WeifenLuo.WinFormsUI.Docking
             return Bounds;
         }
 
+        void IDockDragSource.BeforeEndDrag()
+        {
+        }
+
         void IDockDragSource.EndDrag()
         {
             NativeMethods.SetWindowLong(this.Handle, (int)Win32.GetWindowLongIndex.GWL_EXSTYLE, m_preDragExStyle);

--- a/WinFormsUI/Docking/Interfaces.cs
+++ b/WinFormsUI/Docking/Interfaces.cs
@@ -33,6 +33,7 @@ namespace WeifenLuo.WinFormsUI.Docking
     public interface IDockDragSource : IDragSource
     {
         Rectangle BeginDrag(Point ptMouse);
+        void BeforeEndDrag();
         void EndDrag();
         bool IsDockStateValid(DockState dockState);
         bool CanDockTo(DockPane pane);


### PR DESCRIPTION
Hello, I'm a novice at GitHub. Forgive my rudeness please. 
I need handle something before EndDrag event. So I add BeforeEndDrag event that is called before EndDrag. It also support EndDrag event for DockContent.