### PR TITLE
Add PersistString Property

### DIFF
--- a/WinFormsUI/Docking/DockContent.cs
+++ b/WinFormsUI/Docking/DockContent.cs
@@ -165,6 +165,15 @@ namespace WeifenLuo.WinFormsUI.Docking
         }
 
         [LocalizedCategory("Category_Docking")]
+        [LocalizedDescription("DockContent_PersistString_Description")]
+        [DefaultValue("")]
+        public string PersistString
+        {
+            get { return DockHandler.PersistString; }
+            set { DockHandler.PersistString = value; }
+        }
+
+        [LocalizedCategory("Category_Docking")]
         [LocalizedDescription("DockContent_HideOnClose_Description")]
         [DefaultValue(false)]
         public bool HideOnClose

--- a/WinFormsUI/Docking/DockContentHandler.cs
+++ b/WinFormsUI/Docking/DockContentHandler.cs
@@ -673,9 +673,21 @@ namespace WeifenLuo.WinFormsUI.Docking
             pane.ValidateActiveContent();
         }
 
+        private string m_PersistString = "";
         internal string PersistString
         {
-            get { return GetPersistStringCallback == null ? Form.GetType().ToString() : GetPersistStringCallback(); }
+            get
+            {
+                if (m_PersistString.Length > 0)
+                {
+                    return m_PersistString;
+                }
+                return GetPersistStringCallback == null ? Form.GetType().ToString() : GetPersistStringCallback();
+            }
+            set
+            {
+                m_PersistString = value;
+            }
         }
 
         public GetPersistStringCallback GetPersistStringCallback { get; set; }

--- a/WinFormsUI/ThemeVS2003/VS2003Theme.cs
+++ b/WinFormsUI/ThemeVS2003/VS2003Theme.cs
@@ -55,7 +55,7 @@ namespace WeifenLuo.WinFormsUI.Docking
             return skin;
         }
 
-        private class VS2003DockPaneStripFactory : DockPanelExtender.IDockPaneStripFactory
+        public class VS2003DockPaneStripFactory : DockPanelExtender.IDockPaneStripFactory
         {
             public DockPaneStripBase CreateDockPaneStrip(DockPane pane)
             {
@@ -63,7 +63,7 @@ namespace WeifenLuo.WinFormsUI.Docking
             }
         }
 
-        private class VS2003AutoHideStripFactory : DockPanelExtender.IAutoHideStripFactory
+        public class VS2003AutoHideStripFactory : DockPanelExtender.IAutoHideStripFactory
         {
             public AutoHideStripBase CreateAutoHideStrip(DockPanel panel)
             {
@@ -71,7 +71,7 @@ namespace WeifenLuo.WinFormsUI.Docking
             }
         }
 
-        private class VS2003DockPaneCaptionFactory : DockPanelExtender.IDockPaneCaptionFactory
+        public class VS2003DockPaneCaptionFactory : DockPanelExtender.IDockPaneCaptionFactory
         {
             public DockPaneCaptionBase CreateDockPaneCaption(DockPane pane)
             {


### PR DESCRIPTION
Simply setting this property with a recognizable string, par example if you have to handle more than one instance of a class.
<Instance>.PersistString="something like the name of the instance"

LoadFromXML's DeserializeDockContent function can return the correct Docking.IDockContent by comparing the parameter with the PersistSting Property:

*.LoadFromXml(mStream, _DockContent, True) with _DockContent doing
Docking.DeserializeDockContent(AddressOf GetContentFromPersistString) and
function GetContentFromPersistString(ByVal persistString As String) as IDockContent can do like

       If persistString.Equals(<Instance>.PersistString) Then
            Return <Instance>

with <Instance> created in advance.

Sorry for the example in VB (what I use) instead of CS

sincerely arbor95