### PR TITLE
Fixes some problems with the dark theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ T4MVC.cs
 *.nupkg
 /.vs
 /.idea
+*.bak

--- a/DockSample/MainForm.Designer.cs
+++ b/DockSample/MainForm.Designer.cs
@@ -91,6 +91,11 @@ namespace DockSample
             this.toolBarButtonSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.toolBarButtonLayoutByCode = new System.Windows.Forms.ToolStripButton();
             this.toolBarButtonLayoutByXml = new System.Windows.Forms.ToolStripButton();
+            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            this.subMenuToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.itemAToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.itemBToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.disabledItemToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.dockPanel = new WeifenLuo.WinFormsUI.Docking.DockPanel();
             this.vS2015DarkTheme1 = new WeifenLuo.WinFormsUI.Docking.VS2015DarkTheme();
             this.vS2015BlueTheme1 = new WeifenLuo.WinFormsUI.Docking.VS2015BlueTheme();
@@ -205,7 +210,10 @@ namespace DockSample
             this.menuItemStatusBar,
             this.menuItem2,
             this.menuItemLayoutByCode,
-            this.menuItemLayoutByXml});
+            this.menuItemLayoutByXml,
+            this.toolStripSeparator1,
+            this.subMenuToolStripMenuItem,
+            this.disabledItemToolStripMenuItem});
             this.menuItemView.MergeIndex = 1;
             this.menuItemView.Name = "menuItemView";
             this.menuItemView.Size = new System.Drawing.Size(44, 20);
@@ -612,6 +620,39 @@ namespace DockSample
             this.toolBarButtonLayoutByXml.Size = new System.Drawing.Size(23, 22);
             this.toolBarButtonLayoutByXml.ToolTipText = "Show layout by predefined XML file";
             // 
+            // toolStripSeparator1
+            // 
+            this.toolStripSeparator1.Name = "toolStripSeparator1";
+            this.toolStripSeparator1.Size = new System.Drawing.Size(182, 6);
+            // 
+            // subMenuToolStripMenuItem
+            // 
+            this.subMenuToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.itemAToolStripMenuItem,
+            this.itemBToolStripMenuItem});
+            this.subMenuToolStripMenuItem.Name = "subMenuToolStripMenuItem";
+            this.subMenuToolStripMenuItem.Size = new System.Drawing.Size(185, 22);
+            this.subMenuToolStripMenuItem.Text = "Sub menu";
+            // 
+            // itemAToolStripMenuItem
+            // 
+            this.itemAToolStripMenuItem.Name = "itemAToolStripMenuItem";
+            this.itemAToolStripMenuItem.Size = new System.Drawing.Size(109, 22);
+            this.itemAToolStripMenuItem.Text = "Item A";
+            // 
+            // itemBToolStripMenuItem
+            // 
+            this.itemBToolStripMenuItem.Name = "itemBToolStripMenuItem";
+            this.itemBToolStripMenuItem.Size = new System.Drawing.Size(109, 22);
+            this.itemBToolStripMenuItem.Text = "Item B";
+            // 
+            // disabledItemToolStripMenuItem
+            // 
+            this.disabledItemToolStripMenuItem.Enabled = false;
+            this.disabledItemToolStripMenuItem.Name = "disabledItemToolStripMenuItem";
+            this.disabledItemToolStripMenuItem.Size = new System.Drawing.Size(185, 22);
+            this.disabledItemToolStripMenuItem.Text = "Disabled Item";
+            // 
             // dockPanel
             // 
             this.dockPanel.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -735,5 +776,10 @@ namespace DockSample
         private WeifenLuo.WinFormsUI.Docking.VS2003Theme vS2003Theme1;
         private WeifenLuo.WinFormsUI.Docking.VS2005Theme vS2005Theme1;
         private WeifenLuo.WinFormsUI.Docking.VisualStudioToolStripExtender vsToolStripExtender1;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+        private System.Windows.Forms.ToolStripMenuItem subMenuToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem itemAToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem itemBToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem disabledItemToolStripMenuItem;
     }
 }

--- a/WinFormsUI/Docking/VisualStudioToolStripRenderer.cs
+++ b/WinFormsUI/Docking/VisualStudioToolStripRenderer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Drawing;
 using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
 using System.Windows.Forms;
 
 namespace WeifenLuo.WinFormsUI.Docking
@@ -334,6 +335,79 @@ namespace WeifenLuo.WinFormsUI.Docking
             base.OnRenderOverflowButtonBackground(e);
             if (e.Item.Pressed)
                 _palette.CommandBarMenuPopupDefault.BackgroundTop = cache;
+        }
+
+        protected override void OnRenderArrow(ToolStripArrowRenderEventArgs e)
+        {
+            e.ArrowColor = e.Item.Selected ? _palette.CommandBarMenuPopupHovered.Arrow : _palette.CommandBarMenuPopupDefault.Arrow;
+            base.OnRenderArrow(e);
+        }
+
+        protected override void OnRenderItemCheck(ToolStripItemImageRenderEventArgs e)
+        {
+            ////base.OnRenderItemCheck(e);
+            using (var imageAttr = new ImageAttributes())
+            {
+                Color foreColor = e.Item.Selected ? _palette.CommandBarMenuPopupHovered.Checkmark : _palette.CommandBarMenuPopupDefault.Checkmark;
+                Color backColor = e.Item.Selected ? _palette.CommandBarMenuPopupHovered.CheckmarkBackground : _palette.CommandBarMenuPopupDefault.CheckmarkBackground;
+                Color borderColor = _palette.CommandBarMenuPopupDefault.Border;
+
+                // Create a color map.
+                ColorMap[] colorMap = new ColorMap[1];
+                colorMap[0] = new ColorMap();
+
+                // old color determined from testing
+                colorMap[0].OldColor = Color.FromArgb(4, 2, 4);
+                colorMap[0].NewColor = foreColor;
+                imageAttr.SetRemapTable(colorMap);
+
+                using (var b = new SolidBrush(backColor))
+                {
+                    e.Graphics.FillRectangle(b, e.ImageRectangle);
+                }
+                e.Graphics.DrawImage(e.Image, e.ImageRectangle, 0, 0, e.Image.Width, e.Image.Height, GraphicsUnit.Pixel, imageAttr);
+                using (var p = new Pen(borderColor))
+                {
+                    e.Graphics.DrawRectangle(p, e.ImageRectangle);
+                }
+            }
+        }
+
+        protected override void OnRenderSeparator(ToolStripSeparatorRenderEventArgs e)
+        {
+            Rectangle r = e.Item.ContentRectangle;
+            if (e.Vertical)
+            {
+                using (var p = new Pen(_palette.CommandBarToolbarDefault.Separator))
+                {
+                    e.Graphics.DrawLine(p, r.X, r.Y, r.X, r.Y + r.Height);
+                }
+                using (var p = new Pen(_palette.CommandBarToolbarDefault.SeparatorAccent))
+                {
+                    e.Graphics.DrawLine(p, r.X + 1, r.Y, r.X + 1, r.Y + r.Height);
+                }
+            }
+            else
+            {
+                // if this is a menu, then account for the image column
+                int x1 = r.X;
+                int x2 = r.X + r.Width;
+                var menu = e.ToolStrip as ToolStripDropDownMenu;
+                if (menu != null)
+                {
+                    x1 += menu.Padding.Left;
+                    x2 -= menu.Padding.Right;
+                }
+
+                using (var p = new Pen(_palette.CommandBarToolbarDefault.Separator))
+                {
+                    e.Graphics.DrawLine(p, x1, r.Y, x2, r.Y);
+                }
+                using (var p = new Pen(_palette.CommandBarToolbarDefault.SeparatorAccent))
+                {
+                    e.Graphics.DrawLine(p, x1, r.Y + 1, x2, r.Y + 1);
+                }
+            }
         }
 
         protected override void OnRenderItemText(ToolStripItemTextRenderEventArgs e)


### PR DESCRIPTION
This change renders toolbar arrows, separators, and check marks with the correct theme colors. Also added a few menu items to the test program to help verify colors.