### PR TITLE
Resolve circular dependency issue in nuget packages

### DIFF
--- a/WinFormsUI/Directory.Build.props
+++ b/WinFormsUI/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+ <PropertyGroup>
+   <BaseIntermediateOutputPath>obj/$(MSBuildProjectName)</BaseIntermediateOutputPath>
+ </PropertyGroup>
+</Project>


### PR DESCRIPTION
This fixes one of the issues discussed in https://github.com/dockpanelsuite/dockpanelsuite/issues/616, namely that building Nuget packages causes the DockPanelSuite package to depend on itself.

It turns out this is not the only symptom of the problem. After playing around with it for a while I discovered that the outcome was actually nondeterministic: sometimes all the packages had a dependency on the DockPanelSuite package (including the DockPanelSuite package itself, causing the circular dependency), and sometimes none of them had any dependencies. The first outcome is correct for the themes, but not for the main package. The second outcome is correct for the main package, but not for the themes.

Eventually I figured out that the problem was caused by the fact that the main and theme packages all share the same obj folder. When packages are restored during build, the main and theme packages all write to obj/project.assets.json. This is then used during the build proper to generate the nuspec file for each project. Since they all write to the same project.assets.json file, they all get the same dependencies (whichever is written last wins).

After you know that, the fix is simple: just give each project its own obj folder, which is what this pull request does.