### PR TITLE
Fixes #618

### DIFF
--- a/WinFormsUI/Docking/DockPanel.Persistor.cs
+++ b/WinFormsUI/Docking/DockPanel.Persistor.cs
@@ -232,10 +232,12 @@ namespace WeifenLuo.WinFormsUI.Docking
 
             public static void SaveAsXml(DockPanel dockPanel, Stream stream, Encoding encoding, bool upstream)
             {
-                XmlWriter xmlOut = XmlWriter.Create(stream, new XmlWriterSettings() { Encoding = encoding, Indent = true });
-
-                if (!upstream)
-                    xmlOut.WriteStartDocument();
+                XmlWriter xmlOut = XmlWriter.Create(stream, new XmlWriterSettings() 
+                { 
+                    Encoding = encoding, 
+                    Indent = true,
+                    OmitXmlDeclaration = upstream
+                });
 
                 // Always begin file with identification and warning
                 xmlOut.WriteComment(Strings.DockPanel_Persistor_XmlFileComment1);


### PR DESCRIPTION
This fixes issue #618 by configuring the XmlWriter so that it only emits the XML Declaration when `upstream` is `false`.