### PR TITLE
VisualStudioColorTable - specified colors for ToolStripPanel and ToolStripContainer

### DIFF
--- a/WinFormsUI/Docking/VisualStudioColorTable.cs
+++ b/WinFormsUI/Docking/VisualStudioColorTable.cs
@@ -269,22 +269,22 @@ namespace WeifenLuo.WinFormsUI.Docking
             get { return _palette.CommandBarToolbarDefault.Background; }
         }
 
-        //public override Color ToolStripContentPanelGradientBegin
-        //{
-        //    get { return Color.FromArgb(255, 239, 239, 242); }
-        //}
-        //public override Color ToolStripContentPanelGradientEnd
-        //{
-        //    get { return Color.FromArgb(255, 239, 239, 242); }
-        //}
-        //public override Color ToolStripPanelGradientBegin
-        //{
-        //    get { return Color.FromArgb(255, 239, 239, 242); }
-        //}
-        //public override Color ToolStripPanelGradientEnd
-        //{
-        //    get { return Color.FromArgb(255, 239, 239, 242); }
-        //}
+        public override Color ToolStripContentPanelGradientBegin
+        {
+            get { return _palette.CommandBarMenuDefault.Background; }
+        }
+        public override Color ToolStripContentPanelGradientEnd
+        {
+            get { return _palette.CommandBarMenuDefault.Background; }
+        }
+        public override Color ToolStripPanelGradientBegin
+        {
+            get { return _palette.CommandBarMenuDefault.Background; }
+        }
+        public override Color ToolStripPanelGradientEnd
+        {
+            get { return _palette.CommandBarMenuDefault.Background; }
+        }
 
         public override Color OverflowButtonGradientBegin
         {


### PR DESCRIPTION
Hi there,

I tried to use this library with ToolStrips that are in a ToolStripContainer. After applying one of the Visual Studio themes I noticed that the background of panels in the ToolStripContainer do not conform to the applied theme and appear "stock". I noticed that the associated members are commented out and thus are not overriden, so I added them back.