### PR TITLE
Make ThemeVS2005 thread safe by replacing static graphics objects with instance objects

### DIFF
--- a/WinFormsUI/ThemeVS2005/VS2005AutoHideStrip.cs
+++ b/WinFormsUI/ThemeVS2005/VS2005AutoHideStrip.cs
@@ -50,7 +50,7 @@ namespace WeifenLuo.WinFormsUI.Docking
             get { return DockPanel.Theme.Skin.AutoHideStripSkin.TextFont; }
         }
 
-        private static StringFormat _stringFormatTabHorizontal;
+        private StringFormat _stringFormatTabHorizontal;
         private StringFormat StringFormatTabHorizontal
         {
             get
@@ -73,7 +73,7 @@ namespace WeifenLuo.WinFormsUI.Docking
             }
         }
 
-        private static StringFormat _stringFormatTabVertical;
+        private StringFormat _stringFormatTabVertical;
         private StringFormat StringFormatTabVertical
         {
             get
@@ -150,37 +150,35 @@ namespace WeifenLuo.WinFormsUI.Docking
             get { return _TabGapBetween; }
         }
 
-        private static Pen PenTabBorder
+        private Pen PenTabBorder
         {
             get { return SystemPens.GrayText; }
         }
         #endregion
 
-        private static Matrix _matrixIdentity = new Matrix();
+        private static readonly Matrix _matrixIdentity = new Matrix();
         private static Matrix MatrixIdentity
         {
             get { return _matrixIdentity; }
         }
 
-        private static DockState[] _dockStates;
+        private static readonly DockState[] _dockStates
+            = new[] {
+                DockState.DockLeftAutoHide,
+                DockState.DockRightAutoHide,
+                DockState.DockTopAutoHide,
+                DockState.DockBottomAutoHide,
+            };
         private static DockState[] DockStates
         {
             get
             {
-                if (_dockStates == null)
-                {
-                    _dockStates = new DockState[4];
-                    _dockStates[0] = DockState.DockLeftAutoHide;
-                    _dockStates[1] = DockState.DockRightAutoHide;
-                    _dockStates[2] = DockState.DockTopAutoHide;
-                    _dockStates[3] = DockState.DockBottomAutoHide;
-                }
                 return _dockStates;
             }
         }
 
-        private static GraphicsPath _graphicsPath;
-        internal static GraphicsPath GraphicsPath
+        private GraphicsPath _graphicsPath;
+        private GraphicsPath GraphicsPath
         {
             get
             {

--- a/WinFormsUI/ThemeVS2005/VS2005DockPaneCaption.cs
+++ b/WinFormsUI/ThemeVS2005/VS2005DockPaneCaption.cs
@@ -75,8 +75,8 @@ namespace WeifenLuo.WinFormsUI.Docking
         private const int _ButtonGapRight = 2;
         #endregion
 
-        private static Bitmap _imageButtonClose;
-        private static Bitmap ImageButtonClose
+        private Bitmap _imageButtonClose;
+        private Bitmap ImageButtonClose
         {
             get
             {
@@ -104,8 +104,8 @@ namespace WeifenLuo.WinFormsUI.Docking
             }
         }
 
-        private static Bitmap _imageButtonAutoHide;
-        private static Bitmap ImageButtonAutoHide
+        private Bitmap _imageButtonAutoHide;
+        private Bitmap ImageButtonAutoHide
         {
             get
             {
@@ -116,8 +116,8 @@ namespace WeifenLuo.WinFormsUI.Docking
             }
         }
 
-        private static Bitmap _imageButtonDock;
-        private static Bitmap ImageButtonDock
+        private Bitmap _imageButtonDock;
+        private Bitmap ImageButtonDock
         {
             get
             {
@@ -145,8 +145,8 @@ namespace WeifenLuo.WinFormsUI.Docking
             }
         }
 
-        private static Bitmap _imageButtonOptions;
-        private static Bitmap ImageButtonOptions
+        private Bitmap _imageButtonOptions;
+        private Bitmap ImageButtonOptions
         {
             get
             {
@@ -248,42 +248,14 @@ namespace WeifenLuo.WinFormsUI.Docking
             get	{	return _ButtonGapBetween;	}
         }
 
-        private static string _toolTipClose;
-        private static string ToolTipClose
-        {
-            get
-            {	
-                if (_toolTipClose == null)
-                    _toolTipClose = Strings.DockPaneCaption_ToolTipClose;
-                return _toolTipClose;
-            }
-        }
+        private static string ToolTipClose { get; } = Strings.DockPaneCaption_ToolTipClose;
 
-        private static string _toolTipOptions;
-        private static string ToolTipOptions
-        {
-            get
-            {
-                if (_toolTipOptions == null)
-                    _toolTipOptions = Strings.DockPaneCaption_ToolTipOptions;
+        private static string ToolTipOptions { get; } = Strings.DockPaneCaption_ToolTipOptions;
 
-                return _toolTipOptions;
-            }
-        }
+        private static string ToolTipAutoHide { get; } = Strings.DockPaneCaption_ToolTipAutoHide;
 
-        private static string _toolTipAutoHide;
-        private static string ToolTipAutoHide
-        {
-            get
-            {	
-                if (_toolTipAutoHide == null)
-                    _toolTipAutoHide = Strings.DockPaneCaption_ToolTipAutoHide;
-                return _toolTipAutoHide;
-            }
-        }
-
-        private static Blend _activeBackColorGradientBlend;
-        private static Blend ActiveBackColorGradientBlend
+        private Blend _activeBackColorGradientBlend;
+        private Blend ActiveBackColorGradientBlend
         {
             get
             {
@@ -311,7 +283,7 @@ namespace WeifenLuo.WinFormsUI.Docking
             }
         }
 
-        private static TextFormatFlags _textFormat =
+        private static readonly TextFormatFlags _textFormat =
             TextFormatFlags.SingleLine |
             TextFormatFlags.EndEllipsis |
             TextFormatFlags.VerticalCenter;

--- a/WinFormsUI/ThemeVS2005/VS2005DockPaneStrip.cs
+++ b/WinFormsUI/ThemeVS2005/VS2005DockPaneStrip.cs
@@ -131,10 +131,10 @@ namespace WeifenLuo.WinFormsUI.Docking
         #region Members
 
         private ContextMenuStrip m_selectMenu;
-        private static Bitmap m_imageButtonClose;
+        private Bitmap m_imageButtonClose;
         private InertButton m_buttonClose;
-        private static Bitmap m_imageButtonWindowList;
-        private static Bitmap m_imageButtonWindowListOverflow;
+        private Bitmap m_imageButtonWindowList;
+        private Bitmap m_imageButtonWindowListOverflow;
         private InertButton m_buttonWindowList;
         private IContainer m_components;
         private ToolTip m_toolTip;
@@ -144,8 +144,8 @@ namespace WeifenLuo.WinFormsUI.Docking
         private int m_endDisplayingTab = 0;
         private int m_firstDisplayingTab = 0;
         private bool m_documentTabsOverflow = false;
-        private static string m_toolTipSelect;
-        private static string m_toolTipClose;
+        private string m_toolTipSelect;
+        private string m_toolTipClose;
         private bool m_closeButtonVisible = false;
         private int _selectMenuMargin = 5;
 
@@ -218,7 +218,7 @@ namespace WeifenLuo.WinFormsUI.Docking
             set { _selectMenuMargin = value; }
         }
 
-        private static Bitmap ImageButtonClose
+        private Bitmap ImageButtonClose
         {
             get
             {
@@ -245,7 +245,7 @@ namespace WeifenLuo.WinFormsUI.Docking
             }
         }
 
-        private static Bitmap ImageButtonWindowList
+        private Bitmap ImageButtonWindowList
         {
             get
             {
@@ -256,7 +256,7 @@ namespace WeifenLuo.WinFormsUI.Docking
             }
         }
 
-        private static Bitmap ImageButtonWindowListOverflow
+        private Bitmap ImageButtonWindowListOverflow
         {
             get
             {
@@ -283,10 +283,7 @@ namespace WeifenLuo.WinFormsUI.Docking
             }
         }
 
-        private static GraphicsPath GraphicsPath
-        {
-            get { return VS2005AutoHideStrip.GraphicsPath; }
-        }
+        private GraphicsPath GraphicsPath { get; } = new GraphicsPath();
 
         private IContainer Components
         {
@@ -425,7 +422,7 @@ namespace WeifenLuo.WinFormsUI.Docking
             get { return _ToolWindowTabSeperatorGapBottom; }
         }
 
-        private static string ToolTipClose
+        private string ToolTipClose
         {
             get
             {
@@ -435,7 +432,7 @@ namespace WeifenLuo.WinFormsUI.Docking
             }
         }
 
-        private static string ToolTipSelect
+        private string ToolTipSelect
         {
             get
             {
@@ -555,17 +552,17 @@ namespace WeifenLuo.WinFormsUI.Docking
             get { return _DocumentTextGapRight; }
         }
 
-        private static Pen PenToolWindowTabBorder
+        private Pen PenToolWindowTabBorder
         {
             get { return SystemPens.GrayText; }
         }
 
-        private static Pen PenDocumentTabActiveBorder
+        private Pen PenDocumentTabActiveBorder
         {
             get { return SystemPens.ControlDarkDark; }
         }
 
-        private static Pen PenDocumentTabInactiveBorder
+        private Pen PenDocumentTabInactiveBorder
         {
             get { return SystemPens.GrayText; }
         }

--- a/WinFormsUI/ThemeVS2005/VS2005PaneIndicatorFactory.cs
+++ b/WinFormsUI/ThemeVS2005/VS2005PaneIndicatorFactory.cs
@@ -18,15 +18,15 @@ namespace WeifenLuo.WinFormsUI.ThemeVS2005
         [ToolboxItem(false)]
         internal class VS2005PaneIndicator : PictureBox, IPaneIndicator
         {
-            private static Bitmap _bitmapPaneDiamond = Resources.DockIndicator_PaneDiamond;
-            private static Bitmap _bitmapPaneDiamondLeft = Resources.DockIndicator_PaneDiamond_Left;
-            private static Bitmap _bitmapPaneDiamondRight = Resources.DockIndicator_PaneDiamond_Right;
-            private static Bitmap _bitmapPaneDiamondTop = Resources.DockIndicator_PaneDiamond_Top;
-            private static Bitmap _bitmapPaneDiamondBottom = Resources.DockIndicator_PaneDiamond_Bottom;
-            private static Bitmap _bitmapPaneDiamondFill = Resources.DockIndicator_PaneDiamond_Fill;
-            private static Bitmap _bitmapPaneDiamondHotSpot = Resources.DockIndicator_PaneDiamond_HotSpot;
-            private static Bitmap _bitmapPaneDiamondHotSpotIndex = Resources.DockIndicator_PaneDiamond_HotSpotIndex;
-            private static HotSpotIndex[] _hotSpots =
+            private Bitmap _bitmapPaneDiamond = Resources.DockIndicator_PaneDiamond;
+            private Bitmap _bitmapPaneDiamondLeft = Resources.DockIndicator_PaneDiamond_Left;
+            private Bitmap _bitmapPaneDiamondRight = Resources.DockIndicator_PaneDiamond_Right;
+            private Bitmap _bitmapPaneDiamondTop = Resources.DockIndicator_PaneDiamond_Top;
+            private Bitmap _bitmapPaneDiamondBottom = Resources.DockIndicator_PaneDiamond_Bottom;
+            private Bitmap _bitmapPaneDiamondFill = Resources.DockIndicator_PaneDiamond_Fill;
+            private Bitmap _bitmapPaneDiamondHotSpot = Resources.DockIndicator_PaneDiamond_HotSpot;
+            private Bitmap _bitmapPaneDiamondHotSpotIndex = Resources.DockIndicator_PaneDiamond_HotSpotIndex;
+            private static readonly HotSpotIndex[] _hotSpots =
             {
                 new HotSpotIndex(1, 0, DockStyle.Top),
                 new HotSpotIndex(0, 1, DockStyle.Left),
@@ -35,10 +35,11 @@ namespace WeifenLuo.WinFormsUI.ThemeVS2005
                 new HotSpotIndex(1, 2, DockStyle.Bottom)
             };
 
-            private GraphicsPath _displayingGraphicsPath = DrawHelper.CalculateGraphicsPathFromBitmap(_bitmapPaneDiamond);
+            private GraphicsPath _displayingGraphicsPath;
 
             public VS2005PaneIndicator()
             {
+                _displayingGraphicsPath = DrawHelper.CalculateGraphicsPathFromBitmap(_bitmapPaneDiamond);
                 SizeMode = PictureBoxSizeMode.AutoSize;
                 Image = _bitmapPaneDiamond;
                 Region = new Region(DisplayingGraphicsPath);

--- a/WinFormsUI/ThemeVS2005/VS2005PanelIndicatorFactory.cs
+++ b/WinFormsUI/ThemeVS2005/VS2005PanelIndicatorFactory.cs
@@ -17,16 +17,16 @@ namespace WeifenLuo.WinFormsUI.ThemeVS2005
         [ToolboxItem(false)]
         private class VS2005PanelIndicator : PictureBox, IPanelIndicator
         {
-            private static Image _imagePanelLeft = Resources.DockIndicator_PanelLeft;
-            private static Image _imagePanelRight = Resources.DockIndicator_PanelRight;
-            private static Image _imagePanelTop = Resources.DockIndicator_PanelTop;
-            private static Image _imagePanelBottom = Resources.DockIndicator_PanelBottom;
-            private static Image _imagePanelFill = Resources.DockIndicator_PanelFill;
-            private static Image _imagePanelLeftActive = Resources.DockIndicator_PanelLeft_Active;
-            private static Image _imagePanelRightActive = Resources.DockIndicator_PanelRight_Active;
-            private static Image _imagePanelTopActive = Resources.DockIndicator_PanelTop_Active;
-            private static Image _imagePanelBottomActive = Resources.DockIndicator_PanelBottom_Active;
-            private static Image _imagePanelFillActive = Resources.DockIndicator_PanelFill_Active;
+            private Image _imagePanelLeft = Resources.DockIndicator_PanelLeft;
+            private Image _imagePanelRight = Resources.DockIndicator_PanelRight;
+            private Image _imagePanelTop = Resources.DockIndicator_PanelTop;
+            private Image _imagePanelBottom = Resources.DockIndicator_PanelBottom;
+            private Image _imagePanelFill = Resources.DockIndicator_PanelFill;
+            private Image _imagePanelLeftActive = Resources.DockIndicator_PanelLeft_Active;
+            private Image _imagePanelRightActive = Resources.DockIndicator_PanelRight_Active;
+            private Image _imagePanelTopActive = Resources.DockIndicator_PanelTop_Active;
+            private Image _imagePanelBottomActive = Resources.DockIndicator_PanelBottom_Active;
+            private Image _imagePanelFillActive = Resources.DockIndicator_PanelFill_Active;
 
             public VS2005PanelIndicator(DockStyle dockStyle)
             {


### PR DESCRIPTION
This PR makes the current version of ThemeVS2005 thread safe by replacing static fields with instance fields and eliminating race conditions in static property initialization.

I maintain a Windows Forms application that uses multiple UI threads. We have been using ThemeVS2005Multithreading, which you created from a PR my colleague submitted years ago (#241). I am now updating our application to .NET 6.0. Unfortunately, ThemeVS2005Multithreading does not work correctly with DockPanelSuite 3.1.0 (it fails [the check in `ThemeBase.ApplyTo()`](https://github.com/dockpanelsuite/dockpanelsuite/blob/347d3a7b7c7c149508726a106c5603db20e1b025/WinFormsUI/Docking/ThemeBase.cs#L78-L93)). Please consider accepting these changes and retiring ThemeVS2005Multithreading.